### PR TITLE
Separate monitor preview from server startup

### DIFF
--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ using GStreamerWrapper; // C++/CLI 래퍼 네임스페이스
 using System.IO;
 using System.Security.Policy;
 using System.Text.RegularExpressions;
+using System.Windows.Controls;
 
 
 namespace GStreamerDotNetTest
@@ -56,7 +57,7 @@ namespace GStreamerDotNetTest
 
             private void btnPlay_Click(object sender, RoutedEventArgs e)
             {
-           
+                _player?.StartScreenCaptureServer();
             }
 
             private void btnStop_Click(object sender, RoutedEventArgs e)
@@ -75,7 +76,17 @@ namespace GStreamerDotNetTest
 
         private void btnMonitorPlay_Click(object sender, RoutedEventArgs e)
         {
-            _player?.StartScreenCaptureServer();
+            if (sender is Button btn)
+            {
+                var match = Regex.Match(btn.Name, @"M(\d+)Play", RegexOptions.IgnoreCase);
+                int monitorIndex = 0;
+                if (match.Success)
+                {
+                    int idx = int.Parse(match.Groups[1].Value);
+                    monitorIndex = Math.Max(0, idx - 1);
+                }
+                _player?.StartScreenCapture(monitorIndex);
+            }
         }
     }
 }

--- a/GstPlayer/GStreamerWrapper.cpp
+++ b/GstPlayer/GStreamerWrapper.cpp
@@ -55,6 +55,41 @@ namespace GStreamerWrapper {
     {
         Stop();
     }
+    void GstPlayer::StartScreenCapture(int monitorIndex)
+    {
+        Stop();
+
+        pipeline = gst_pipeline_new("screen-preview");
+        GstElement* src = gst_element_factory_make("d3d11screencapturesrc", "src");
+        GstElement* conv = gst_element_factory_make("d3d11convert", "conv");
+        GstElement* sink = gst_element_factory_make("d3d11videosink", "sink");
+
+        if (!pipeline || !src || !conv || !sink) {
+            g_printerr("파이프라인 생성 실패\n");
+            if (pipeline) { gst_object_unref(pipeline); pipeline = nullptr; }
+            return;
+        }
+
+        g_object_set(src, "monitor-index", monitorIndex, "show-cursor", TRUE, NULL);
+
+        gst_bin_add_many(GST_BIN(pipeline), src, conv, sink, NULL);
+        if (!gst_element_link_many(src, conv, sink, NULL)) {
+            g_printerr("요소 연결 실패\n");
+            gst_object_unref(pipeline);
+            pipeline = nullptr;
+            return;
+        }
+
+        gcHandle = GCHandle::Alloc(this);
+
+        GstBus* bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));
+        gst_bus_add_signal_watch(bus);
+        g_signal_connect(bus, "message", G_CALLBACK(BusMessageCallback), GCHandle::ToIntPtr(gcHandle).ToPointer());
+        gst_bus_set_sync_handler(bus, BusSyncHandler, GCHandle::ToIntPtr(gcHandle).ToPointer(), NULL);
+        g_object_unref(bus);
+
+        gst_element_set_state(pipeline, GST_STATE_PLAYING);
+    }
     void GstPlayer::StartScreenCaptureServer()
     {
         // 기존 파이프라인 정지 후 새로운 RTSP 서버 실행
@@ -68,6 +103,9 @@ namespace GStreamerWrapper {
             gst_element_set_state(pipeline, GST_STATE_NULL);
             gst_object_unref(pipeline);
             pipeline = nullptr;
+        }
+        if (gcHandle.IsAllocated) {
+            gcHandle.Free();
         }
     }
 

--- a/GstPlayer/GStreamerWrapper.h
+++ b/GstPlayer/GStreamerWrapper.h
@@ -5,6 +5,7 @@
 #include <vcclr.h>
 #include <Windows.h>
 using namespace System;
+using namespace System::Runtime::InteropServices; // for GCHandle
 
 namespace GStreamerWrapper {
 
@@ -12,7 +13,7 @@ namespace GStreamerWrapper {
     {
     private:
         GstElement* pipeline;
-        //HWND videoHwnd; // 창 핸들(HWND)을 직접 저장
+        GCHandle gcHandle;
 
         // C#에서 호출할 수 없도록 private으로 선언
         static void BusMessageCallback(GstBus* bus, GstMessage* msg, gpointer data);
@@ -27,6 +28,7 @@ namespace GStreamerWrapper {
         // C++ CLI에서는 !GstPlayer() 형태의 Finalizer도 정의해주는 것이 좋습니다.
         !GstPlayer();
 
+        void StartScreenCapture(int monitorIndex);
         void StartScreenCaptureServer();
         void Stop();
 


### PR DESCRIPTION
## Summary
- Add `StartScreenCapture` to preview a selected monitor in the window
- Wire monitor play buttons to screen preview and server play button to RTSP server start
- Track `GCHandle` lifetime to avoid leaks when stopping pipelines

## Testing
- `dotnet build GStreamerDotNetTest/StreamerDotNet.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be7578aae0832fbb02a21da4ebe8ab