### PR TITLE
Force RTSP clients to disconnect on shutdown

### DIFF
--- a/GstPlayer/ScreenCaptureServer.cpp
+++ b/GstPlayer/ScreenCaptureServer.cpp
@@ -29,6 +29,7 @@ struct RtspServerContext {
     GMainLoop* loop = nullptr;
     GstRTSPServer* server = nullptr;
     GstRTSPMountPoints* mounts = nullptr;
+    guint server_source_id = 0; // attach된 서버 소스 ID
     std::vector<GstRTSPMediaFactory*> factories; // 정리용 보관
 };
 
@@ -57,6 +58,11 @@ static void client_connected_callback(GstRTSPServer*, GstRTSPClient* client, gpo
         g_object_unref(c);
     }
     g_signal_connect(client, "closed", G_CALLBACK(client_closed_callback), user_data);
+}
+
+static GstRTSPFilterResult force_client_disconnect(GstRTSPServer*, GstRTSPClient* client, gpointer) {
+    gst_rtsp_client_close(client);
+    return GST_RTSP_FILTER_REMOVE;
 }
 
 // ====== 커스텀 Factory ======
@@ -407,8 +413,11 @@ static void configure_rtsp_server(RtspServerContext * ctx) {
 }
 
 static bool start_rtsp_server(RtspServerContext * ctx) {
-    guint id = gst_rtsp_server_attach(ctx->server, NULL);
-    if (id == 0) { g_printerr("RTSP 서버 attach 실패\n"); return false; }
+    ctx->server_source_id = gst_rtsp_server_attach(ctx->server, NULL);
+    if (ctx->server_source_id == 0) {
+        g_printerr("RTSP 서버 attach 실패\n");
+        return false;
+    }
     g_print("RTSP 서버가 시작되었습니다. 예: rtsp://192.168.10.252:10554/screen1\n");
     g_main_loop_run(ctx->loop);
     return true;
@@ -416,6 +425,10 @@ static bool start_rtsp_server(RtspServerContext * ctx) {
 
 static void cleanup_resources(RtspServerContext * ctx) {
     g_print("5. 리소스 해제...\n");
+    if (ctx->server_source_id != 0) {
+        g_source_remove(ctx->server_source_id);
+        ctx->server_source_id = 0;
+    }
     if (ctx->mounts)  g_object_unref(ctx->mounts);
     for (auto* f : ctx->factories) { if (f) g_object_unref(f); }
     if (ctx->server)  g_object_unref(ctx->server);
@@ -444,14 +457,20 @@ void RunScreenCaptureRtspServer() {
 }
 
 void StopScreenCaptureRtspServer() {
+    if (g_ctx.server) {
+        gst_rtsp_server_client_filter(g_ctx.server, force_client_disconnect, nullptr);
+        GstRTSPSessionPool* pool = gst_rtsp_server_get_session_pool(g_ctx.server);
+        if (pool) {
+            gst_rtsp_session_pool_cleanup(pool);
+            g_object_unref(pool);
+        }
+    }
     if (g_ctx.loop) {
         g_main_loop_quit(g_ctx.loop);
-
         GMainContext* ctx = g_main_loop_get_context(g_ctx.loop);
         if (ctx) {
             g_main_context_wakeup(ctx);
         }
-
     }
     if (g_server_thread.joinable()) {
         g_server_thread.join();


### PR DESCRIPTION
## Summary
- track RTSP server attach source id
- remove server source during cleanup to allow shutdown
- force disconnection of any connected RTSP clients and clean session pool before quitting loop

## Testing
- `dotnet build` *(fails: imported project "/Microsoft.Cpp.Default.props" not found; .NETFramework v4.8 reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_b_68be8656dde8832f9e9ce31e791d7db2