### PR TITLE
Allow dynamic RTSP server IP and stream tabs

### DIFF
--- a/GStreamerDotNetTest/MainWindow.xaml
+++ b/GStreamerDotNetTest/MainWindow.xaml
@@ -48,18 +48,11 @@
                                 <ColumnDefinition Width="6*"/>
                             </Grid.ColumnDefinitions>
                             <Label Content="Num of stream:" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5"/>
-                            <TextBox Name="Textbox_numofstreamer" Grid.Column="1" />
+                            <TextBox Name="Textbox_numofstreamer" Grid.Column="1" TextChanged="Textbox_numofstreamer_TextChanged" />
                         </Grid>
                     </StackPanel>
-                    <TabControl Grid.Row="1">
-                        <TabItem Header="stream1">
-                            <Grid Background="#FFE5E5E5"/>
-                        </TabItem>
-                        <TabItem Header="stream2">
-                            <Grid Background="#FFE5E5E5"/>
-                        </TabItem>
-                    </TabControl>
-                    <Button Grid.Row="1" Content="save setting" HorizontalAlignment="Left" Margin="10,10,0,10" VerticalAlignment="Center" Width="75"/>
+                    <TabControl Grid.Row="1" x:Name="StreamSettingsTab"/>
+                    <Button Grid.Row="2" Content="save setting" HorizontalAlignment="Left" Margin="10,10,0,10" VerticalAlignment="Center" Width="75" Click="BtnSaveSetting_Click"/>
                 </Grid>
             </TabItem>
           

--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -28,6 +28,19 @@ namespace GStreamerDotNetTest
             private GstPlayer _player;
             private GstVideoHost _videoHost;
 
+            private class StreamSetting
+            {
+                public ComboBox Monitor;
+                public TextBox CropX, CropY, CropW, CropH;
+                public ComboBox Resolution;
+                public TextBox FrameRate, Bitrate, Keyframe;
+                public ComboBox BitrateControl;
+                public ComboBox Profile;
+                public TabItem Tab;
+            }
+
+            private readonly List<StreamSetting> _streamSettings = new List<StreamSetting>();
+
             public MainWindow()
             {
                 InitializeComponent();
@@ -57,7 +70,8 @@ namespace GStreamerDotNetTest
 
             private void btnPlay_Click(object sender, RoutedEventArgs e)
             {
-                _player?.StartScreenCaptureServer();
+                string serverIp = Textbox_serverIP.Text;
+                _player?.StartScreenCaptureServer(serverIp);
             }
 
             private void btnStop_Click(object sender, RoutedEventArgs e)
@@ -87,6 +101,92 @@ namespace GStreamerDotNetTest
                 }
                 _player?.StartScreenCapture(monitorIndex);
             }
+        }
+
+        private void Textbox_numofstreamer_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (int.TryParse(Textbox_numofstreamer.Text, out int count) && count >= 0)
+            {
+                UpdateStreamTabs(count);
+            }
+        }
+
+        private void UpdateStreamTabs(int count)
+        {
+            StreamSettingsTab.Items.Clear();
+            _streamSettings.Clear();
+            for (int i = 0; i < count; i++)
+            {
+                var setting = CreateStreamSettingTab(i);
+                _streamSettings.Add(setting);
+                StreamSettingsTab.Items.Add(setting.Tab);
+            }
+        }
+
+        private StreamSetting CreateStreamSettingTab(int index)
+        {
+            var setting = new StreamSetting();
+            var tab = new TabItem { Header = $"stream{index + 1}" };
+            var root = new StackPanel { Margin = new Thickness(10) };
+
+            setting.Monitor = new ComboBox();
+            for (int i = 0; i < 4; i++) setting.Monitor.Items.Add(i.ToString());
+            root.Children.Add(LabeledControl("Monitor Index:", setting.Monitor));
+
+            setting.CropX = new TextBox { Width = 40 };
+            setting.CropY = new TextBox { Width = 40 };
+            setting.CropW = new TextBox { Width = 40 };
+            setting.CropH = new TextBox { Width = 40 };
+            var cropPanel = new StackPanel { Orientation = Orientation.Horizontal };
+            cropPanel.Children.Add(new Label { Content = "X" }); cropPanel.Children.Add(setting.CropX);
+            cropPanel.Children.Add(new Label { Content = "Y" }); cropPanel.Children.Add(setting.CropY);
+            cropPanel.Children.Add(new Label { Content = "W" }); cropPanel.Children.Add(setting.CropW);
+            cropPanel.Children.Add(new Label { Content = "H" }); cropPanel.Children.Add(setting.CropH);
+            root.Children.Add(LabeledControl("Crop:", cropPanel));
+
+            setting.Resolution = new ComboBox();
+            setting.Resolution.Items.Add("Input");
+            setting.Resolution.Items.Add("1080p");
+            setting.Resolution.Items.Add("720p");
+            root.Children.Add(LabeledControl("Resolution:", setting.Resolution));
+
+            setting.FrameRate = new TextBox { Width = 60 };
+            root.Children.Add(LabeledControl("Frame rate:", setting.FrameRate));
+
+            setting.Bitrate = new TextBox { Width = 60 };
+            root.Children.Add(LabeledControl("Bitrate:", setting.Bitrate));
+
+            setting.BitrateControl = new ComboBox();
+            setting.BitrateControl.Items.Add("CBR");
+            setting.BitrateControl.Items.Add("VBR");
+            root.Children.Add(LabeledControl("Bitrate Control:", setting.BitrateControl));
+
+            setting.Keyframe = new TextBox { Width = 60 };
+            root.Children.Add(LabeledControl("Keyframe Interval:", setting.Keyframe));
+
+            setting.Profile = new ComboBox();
+            setting.Profile.Items.Add("main");
+            setting.Profile.Items.Add("baseline");
+            setting.Profile.Items.Add("high");
+            root.Children.Add(LabeledControl("Profile:", setting.Profile));
+
+            tab.Content = root;
+            setting.Tab = tab;
+            return setting;
+        }
+
+        private FrameworkElement LabeledControl(string label, Control control)
+        {
+            var panel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 2, 0, 2) };
+            panel.Children.Add(new Label { Content = label, Width = 120 });
+            panel.Children.Add(control);
+            return panel;
+        }
+
+        private void BtnSaveSetting_Click(object sender, RoutedEventArgs e)
+        {
+            string serverIp = Textbox_serverIP.Text;
+            _player?.StartScreenCaptureServer(serverIp);
         }
     }
 }

--- a/GstPlayer/GStreamerWrapper.cpp
+++ b/GstPlayer/GStreamerWrapper.cpp
@@ -91,13 +91,16 @@ namespace GStreamerWrapper {
 
         gst_element_set_state(pipeline, GST_STATE_PLAYING);
     }
-    void GstPlayer::StartScreenCaptureServer()
+    void GstPlayer::StartScreenCaptureServer(String^ serverIp)
     {
         // 기존 파이프라인 정지 후 새로운 RTSP 서버 실행. RTSP 서버는
         // 내부적으로 별도의 스레드에서 실행되므로 이 호출은 UI 스레드
         // 를 블로킹하지 않습니다.
         Stop();
-        RunScreenCaptureRtspServer();
+
+        IntPtr ipPtr = Marshal::StringToHGlobalAnsi(serverIp);
+        RunScreenCaptureRtspServer(static_cast<const char*>(ipPtr.ToPointer()));
+        Marshal::FreeHGlobal(ipPtr);
     }
 
     void GstPlayer::Stop()

--- a/GstPlayer/GStreamerWrapper.h
+++ b/GstPlayer/GStreamerWrapper.h
@@ -29,7 +29,10 @@ namespace GStreamerWrapper {
         !GstPlayer();
 
         void StartScreenCapture(int monitorIndex);
-        void StartScreenCaptureServer();
+        // Starts the RTSP server. The IP address to bind to is provided by
+        // the managed layer so that the server can be configured at
+        // runtime instead of relying on a compile-time macro.
+        void StartScreenCaptureServer(String^ serverIp);
         void Stop();
 
         static void Initialize();

--- a/GstPlayer/ScreenCaptureServer.cpp
+++ b/GstPlayer/ScreenCaptureServer.cpp
@@ -11,9 +11,13 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-#define SIP "192.168.10.252"
-
 namespace GStreamerWrapper {
+
+// Server IP address supplied from the .NET layer. Previously this value
+// was specified via the `SIP` macro making it impossible to configure at
+// run time.  It is now stored in a global that is set when the server is
+// started.
+static std::string g_server_ip;
 
 // ===== 모니터 개수 탐지 =====
 static BOOL CALLBACK CountMonitorsProc(HMONITOR, HDC, LPRECT, LPARAM lParam) {
@@ -347,7 +351,7 @@ static GstRTSPMediaFactory* create_factory_for_monitor(int monitor_index) {
     g_signal_connect(f, "media-configure", G_CALLBACK(on_media_configure), NULL);
 
     gst_rtsp_media_factory_set_protocols(GST_RTSP_MEDIA_FACTORY(f), GST_RTSP_LOWER_TRANS_UDP_MCAST);
-    gst_rtsp_media_factory_set_multicast_iface(GST_RTSP_MEDIA_FACTORY(f), SIP);
+    gst_rtsp_media_factory_set_multicast_iface(GST_RTSP_MEDIA_FACTORY(f), g_server_ip.c_str());
 
     const int base_octet = 11 + monitor_index;
     const int base_port = 15000 + monitor_index * 20;
@@ -382,7 +386,7 @@ static void initialize_gstreamer(int* argc, char*** argv, RtspServerContext * ct
     gst_init(argc, argv);
     ctx->loop = g_main_loop_new(NULL, FALSE);
     ctx->server = gst_rtsp_server_new();
-    gst_rtsp_server_set_address(ctx->server, SIP);
+    gst_rtsp_server_set_address(ctx->server, g_server_ip.c_str());
     gst_rtsp_server_set_service(ctx->server, "10554");
 
     g_object_set(G_OBJECT(ctx->server), "session-timeout", 2, NULL);
@@ -408,7 +412,7 @@ static void configure_rtsp_server(RtspServerContext * ctx) {
         ctx->factories.push_back(f);
         std::ostringstream mount; mount << "/screen" << (i + 1);
         gst_rtsp_mount_points_add_factory(ctx->mounts, mount.str().c_str(), f);
-        g_print("  - mount: rtsp://192.168.10.252:10554%s\n", mount.str().c_str());
+        g_print("  - mount: rtsp://%s:10554%s\n", g_server_ip.c_str(), mount.str().c_str());
     }
 }
 
@@ -418,7 +422,7 @@ static bool start_rtsp_server(RtspServerContext * ctx) {
         g_printerr("RTSP 서버 attach 실패\n");
         return false;
     }
-    g_print("RTSP 서버가 시작되었습니다. 예: rtsp://192.168.10.252:10554/screen1\n");
+    g_print("RTSP 서버가 시작되었습니다. 예: rtsp://%s:10554/screen1\n", g_server_ip.c_str());
     g_main_loop_run(ctx->loop);
     return true;
 }
@@ -440,8 +444,16 @@ static void cleanup_resources(RtspServerContext * ctx) {
     ctx->factories.clear();
 }
 
-// 서버를 백그라운드 스레드에서 실행하도록 수정
-void RunScreenCaptureRtspServer() {
+// 서버를 백그라운드 스레드에서 실행하도록 수정. `serverIp`는 서버가
+// 바인딩할 주소이며 전역 변수로 보관되어 이후 GStreamer 초기화 시
+// 사용된다.
+void RunScreenCaptureRtspServer(const char* serverIp) {
+    if (serverIp) {
+        g_server_ip = serverIp;
+    } else {
+        g_server_ip.clear();
+    }
+
     if (g_server_thread.joinable()) {
         g_printerr("RTSP server already running\n");
         return;

--- a/GstPlayer/ScreenCaptureServer.h
+++ b/GstPlayer/ScreenCaptureServer.h
@@ -3,7 +3,12 @@
 namespace GStreamerWrapper {
 // Starts the RTSP screen capture server on a background thread. This
 // call returns immediately and does not block the caller's thread.
-void RunScreenCaptureRtspServer();
+//
+// `serverIp` is the IP address the server will bind to. It was
+// previously hard coded as a macro inside the implementation but is now
+// provided dynamically from the .NET side so that applications can
+// configure the address at run time.
+void RunScreenCaptureRtspServer(const char* serverIp);
 
 // Stops the RTSP screen capture server if it is running. Safe to call
 // even when the server is not active.


### PR DESCRIPTION
## Summary
- Let .NET pass the RTSP server IP instead of using a fixed macro
- Add dynamic stream settings tabs and forward saved server IP to native side
- Wire up server start with the user-provided address

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be9ae90390832f8eedd0685e4642a8