### PR TITLE
feat: configure multiple RTSP streams

### DIFF
--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -27,6 +27,7 @@ namespace GStreamerDotNetTest
         {
             private GstPlayer _player;
             private GstVideoHost _videoHost;
+            private GstPlayer.StreamConfig[] _configs = Array.Empty<GstPlayer.StreamConfig>();
 
             private class StreamSetting
             {
@@ -68,10 +69,36 @@ namespace GStreamerDotNetTest
                 _player = new GstPlayer(_videoHost.Handle);
             }
 
+            private GstPlayer.StreamConfig[] CollectStreamConfigs()
+            {
+                var list = new List<GstPlayer.StreamConfig>();
+                foreach (var s in _streamSettings)
+                {
+                    var cfg = new GstPlayer.StreamConfig();
+                    int.TryParse(s.Monitor.Text, out cfg.MonitorIndex);
+                    int.TryParse(s.CropX.Text, out cfg.CropX);
+                    int.TryParse(s.CropY.Text, out cfg.CropY);
+                    int.TryParse(s.CropW.Text, out cfg.CropW);
+                    int.TryParse(s.CropH.Text, out cfg.CropH);
+                    switch (s.Resolution.SelectedItem as string)
+                    {
+                        case "1080p": cfg.Width = 1920; cfg.Height = 1080; break;
+                        case "720p": cfg.Width = 1280; cfg.Height = 720; break;
+                        default: cfg.Width = 0; cfg.Height = 0; break;
+                    }
+                    int.TryParse(s.FrameRate.Text, out cfg.Framerate);
+                    int.TryParse(s.Bitrate.Text, out cfg.BitrateKbps);
+                    int.TryParse(s.Keyframe.Text, out cfg.KeyframeInterval);
+                    list.Add(cfg);
+                }
+                return list.ToArray();
+            }
+
             private void btnPlay_Click(object sender, RoutedEventArgs e)
             {
                 string serverIp = Textbox_serverIP.Text;
-                _player?.StartScreenCaptureServer(serverIp);
+                _configs = CollectStreamConfigs();
+                _player?.StartScreenCaptureServer(serverIp, _configs);
             }
 
             private void btnStop_Click(object sender, RoutedEventArgs e)
@@ -99,7 +126,10 @@ namespace GStreamerDotNetTest
                     int idx = int.Parse(match.Groups[1].Value);
                     monitorIndex = Math.Max(0, idx - 1);
                 }
-                _player?.StartScreenCapture(monitorIndex);
+                if (_configs != null && monitorIndex < _configs.Length)
+                {
+                    _player?.StartScreenCapture(_configs[monitorIndex]);
+                }
             }
         }
 
@@ -183,10 +213,9 @@ namespace GStreamerDotNetTest
             return panel;
         }
 
-        private void BtnSaveSetting_Click(object sender, RoutedEventArgs e)
-        {
-            string serverIp = Textbox_serverIP.Text;
-            _player?.StartScreenCaptureServer(serverIp);
-        }
+            private void BtnSaveSetting_Click(object sender, RoutedEventArgs e)
+            {
+                _configs = CollectStreamConfigs();
+            }
     }
 }

--- a/GstPlayer/GStreamerWrapper.cpp
+++ b/GstPlayer/GStreamerWrapper.cpp
@@ -2,6 +2,9 @@
 #include "GStreamerWrapper.h"
 #include "ScreenCaptureServer.h"
 
+#include <vector>
+#include <sstream>
+
 // 필요한 .NET 네임스페이스 추가
 using namespace System::Runtime::InteropServices; // GCHandle을 위해 추가
 using namespace System::Diagnostics;             // Debug 클래스를 위해 추가
@@ -56,25 +59,41 @@ namespace GStreamerWrapper {
     {
         Stop();
     }
-    void GstPlayer::StartScreenCapture(int monitorIndex)
+    void GstPlayer::StartScreenCapture(StreamConfig config)
     {
         Stop();
 
         pipeline = gst_pipeline_new("screen-preview");
         GstElement* src = gst_element_factory_make("d3d11screencapturesrc", "src");
         GstElement* conv = gst_element_factory_make("d3d11convert", "conv");
+        GstElement* capsfilter = gst_element_factory_make("capsfilter", "caps");
         GstElement* sink = gst_element_factory_make("d3d11videosink", "sink");
 
-        if (!pipeline || !src || !conv || !sink) {
+        if (!pipeline || !src || !conv || !capsfilter || !sink) {
             g_printerr("파이프라인 생성 실패\n");
             if (pipeline) { gst_object_unref(pipeline); pipeline = nullptr; }
             return;
         }
 
-        g_object_set(src, "monitor-index", monitorIndex, "show-cursor", TRUE, NULL);
+        g_object_set(src,
+            "monitor-index", config.MonitorIndex,
+            "show-cursor", TRUE,
+            "left", config.CropX,
+            "top", config.CropY,
+            "width", config.CropW,
+            "height", config.CropH,
+            NULL);
 
-        gst_bin_add_many(GST_BIN(pipeline), src, conv, sink, NULL);
-        if (!gst_element_link_many(src, conv, sink, NULL)) {
+        std::ostringstream caps_str;
+        caps_str << "video/x-raw,format=NV12,width=" << config.Width
+                 << ",height=" << config.Height
+                 << ",framerate=" << config.Framerate << "/1";
+        GstCaps* caps = gst_caps_from_string(caps_str.str().c_str());
+        g_object_set(capsfilter, "caps", caps, NULL);
+        gst_caps_unref(caps);
+
+        gst_bin_add_many(GST_BIN(pipeline), src, conv, capsfilter, sink, NULL);
+        if (!gst_element_link_many(src, conv, capsfilter, sink, NULL)) {
             g_printerr("요소 연결 실패\n");
             gst_object_unref(pipeline);
             pipeline = nullptr;
@@ -82,7 +101,6 @@ namespace GStreamerWrapper {
         }
 
         gcHandle = GCHandle::Alloc(this);
-
         GstBus* bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));
         gst_bus_add_signal_watch(bus);
         g_signal_connect(bus, "message", G_CALLBACK(BusMessageCallback), GCHandle::ToIntPtr(gcHandle).ToPointer());
@@ -91,15 +109,33 @@ namespace GStreamerWrapper {
 
         gst_element_set_state(pipeline, GST_STATE_PLAYING);
     }
-    void GstPlayer::StartScreenCaptureServer(String^ serverIp)
+
+    void GstPlayer::StartScreenCaptureServer(String^ serverIp, array<StreamConfig>^ configs)
     {
-        // 기존 파이프라인 정지 후 새로운 RTSP 서버 실행. RTSP 서버는
-        // 내부적으로 별도의 스레드에서 실행되므로 이 호출은 UI 스레드
-        // 를 블로킹하지 않습니다.
         Stop();
 
         IntPtr ipPtr = Marshal::StringToHGlobalAnsi(serverIp);
-        RunScreenCaptureRtspServer(static_cast<const char*>(ipPtr.ToPointer()));
+
+        std::vector<StreamConfigNative> nativeConfigs;
+        for each (StreamConfig cfg in configs)
+        {
+            StreamConfigNative ncfg;
+            ncfg.monitor_index = cfg.MonitorIndex;
+            ncfg.crop_x = cfg.CropX;
+            ncfg.crop_y = cfg.CropY;
+            ncfg.crop_w = cfg.CropW;
+            ncfg.crop_h = cfg.CropH;
+            ncfg.width = cfg.Width;
+            ncfg.height = cfg.Height;
+            ncfg.framerate = cfg.Framerate;
+            ncfg.bitrate_kbps = cfg.BitrateKbps;
+            ncfg.keyframe_interval = cfg.KeyframeInterval;
+            nativeConfigs.push_back(ncfg);
+        }
+
+        RunScreenCaptureRtspServer(static_cast<const char*>(ipPtr.ToPointer()),
+                                   nativeConfigs.data(),
+                                   (int)nativeConfigs.size());
         Marshal::FreeHGlobal(ipPtr);
     }
 

--- a/GstPlayer/GStreamerWrapper.h
+++ b/GstPlayer/GStreamerWrapper.h
@@ -9,30 +9,37 @@ using namespace System::Runtime::InteropServices; // for GCHandle
 
 namespace GStreamerWrapper {
 
+    public value struct StreamConfig
+    {
+        int MonitorIndex;
+        int CropX;
+        int CropY;
+        int CropW;
+        int CropH;
+        int Width;
+        int Height;
+        int Framerate;
+        int BitrateKbps;
+        int KeyframeInterval;
+    };
+
     public ref class GstPlayer
     {
     private:
         GstElement* pipeline;
         GCHandle gcHandle;
 
-        // C#에서 호출할 수 없도록 private으로 선언
         static void BusMessageCallback(GstBus* bus, GstMessage* msg, gpointer data);
         void HandleBusMessage(GstMessage* msg);
 
     public:
         HWND videoHwnd;
-        // 생성자가 Control 대신 IntPtr을 받도록 수정
         GstPlayer(IntPtr windowHandle);
-        // 소멸자 (IDisposable 패턴을 위해 필요)
         ~GstPlayer();
-        // C++ CLI에서는 !GstPlayer() 형태의 Finalizer도 정의해주는 것이 좋습니다.
         !GstPlayer();
 
-        void StartScreenCapture(int monitorIndex);
-        // Starts the RTSP server. The IP address to bind to is provided by
-        // the managed layer so that the server can be configured at
-        // runtime instead of relying on a compile-time macro.
-        void StartScreenCaptureServer(String^ serverIp);
+        void StartScreenCapture(StreamConfig config);
+        void StartScreenCaptureServer(String^ serverIp, array<StreamConfig>^ configs);
         void Stop();
 
         static void Initialize();

--- a/GstPlayer/ScreenCaptureServer.cpp
+++ b/GstPlayer/ScreenCaptureServer.cpp
@@ -18,6 +18,7 @@ namespace GStreamerWrapper {
 // run time.  It is now stored in a global that is set when the server is
 // started.
 static std::string g_server_ip;
+static std::vector<StreamConfigNative> g_configs;
 
 // ===== 모니터 개수 탐지 =====
 static BOOL CALLBACK CountMonitorsProc(HMONITOR, HDC, LPRECT, LPARAM lParam) {
@@ -328,15 +329,15 @@ static void my_media_factory_init(MyMediaFactory * self) {
 #endif
 }
 
-static GstRTSPMediaFactory* create_factory_for_monitor(int monitor_index) {
+static GstRTSPMediaFactory* create_factory_from_config(const StreamConfigNative& cfg) {
     const bool ENABLE_AUDIO = true;
 
     MyMediaFactory* f = (MyMediaFactory*)g_object_new(my_media_factory_get_type(), NULL);
-    f->monitor_index = monitor_index;
-    f->out_w = 1920;
-    f->out_h = 1200;
-    f->fps = 30;
-    f->v_bitrate_kbps = 8000;
+    f->monitor_index = cfg.monitor_index;
+    f->out_w = cfg.width > 0 ? cfg.width : 1920;
+    f->out_h = cfg.height > 0 ? cfg.height : 1200;
+    f->fps = cfg.framerate > 0 ? cfg.framerate : 30;
+    f->v_bitrate_kbps = cfg.bitrate_kbps > 0 ? cfg.bitrate_kbps : 8000;
     f->a_bitrate_bps = 128000;
     f->enable_audio = ENABLE_AUDIO;
 
@@ -403,12 +404,9 @@ static void initialize_gstreamer(int* argc, char*** argv, RtspServerContext * ct
 }
 
 static void configure_rtsp_server(RtspServerContext * ctx) {
-    int monitor_count = DetectMonitorCount();
-    g_print("감지된 모니터 개수: %d\n", monitor_count);
-    ctx->factories.reserve(monitor_count);
-
-    for (int i = 0; i < monitor_count; ++i) {
-        GstRTSPMediaFactory* f = create_factory_for_monitor(i);
+    ctx->factories.reserve(g_configs.size());
+    for (size_t i = 0; i < g_configs.size(); ++i) {
+        GstRTSPMediaFactory* f = create_factory_from_config(g_configs[i]);
         ctx->factories.push_back(f);
         std::ostringstream mount; mount << "/screen" << (i + 1);
         gst_rtsp_mount_points_add_factory(ctx->mounts, mount.str().c_str(), f);
@@ -447,7 +445,10 @@ static void cleanup_resources(RtspServerContext * ctx) {
 // 서버를 백그라운드 스레드에서 실행하도록 수정. `serverIp`는 서버가
 // 바인딩할 주소이며 전역 변수로 보관되어 이후 GStreamer 초기화 시
 // 사용된다.
-void RunScreenCaptureRtspServer(const char* serverIp) {
+void RunScreenCaptureRtspServer(const char* serverIp,
+                                const StreamConfigNative* configs,
+                                int count) {
+    g_configs.assign(configs, configs + count);
     if (serverIp) {
         g_server_ip = serverIp;
     } else {

--- a/GstPlayer/ScreenCaptureServer.h
+++ b/GstPlayer/ScreenCaptureServer.h
@@ -1,14 +1,28 @@
 #pragma once
 
 namespace GStreamerWrapper {
-// Starts the RTSP screen capture server on a background thread. This
-// call returns immediately and does not block the caller's thread.
-//
-// `serverIp` is the IP address the server will bind to. It was
-// previously hard coded as a macro inside the implementation but is now
-// provided dynamically from the .NET side so that applications can
-// configure the address at run time.
-void RunScreenCaptureRtspServer(const char* serverIp);
+
+// Stream configuration passed from the managed layer. This simple
+// structure is shared between the C++ implementation and the C++/CLI
+// wrapper.
+struct StreamConfigNative {
+    int monitor_index;
+    int crop_x;
+    int crop_y;
+    int crop_w;
+    int crop_h;
+    int width;
+    int height;
+    int framerate;
+    int bitrate_kbps;
+    int keyframe_interval;
+};
+
+// Starts the RTSP screen capture server on a background thread hosting
+// `count` streams described by `configs`.
+void RunScreenCaptureRtspServer(const char* serverIp,
+                                const StreamConfigNative* configs,
+                                int count);
 
 // Stops the RTSP screen capture server if it is running. Safe to call
 // even when the server is not active.


### PR DESCRIPTION
## Summary
- allow passing per-stream configuration from C# to native layer
- host multiple RTSP streams based on configured settings
- enable preview using the same pipeline settings

## Testing
- `dotnet build StreamerGst.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bf723eeea8832f92f56b3879fb2d2f