### PR TITLE
Fix crop settings and derive input resolution from monitor

### DIFF
--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.IO;
 using System.Security.Policy;
 using System.Text.RegularExpressions;
 using System.Windows.Controls;
+using Forms = System.Windows.Forms;
 
 
 namespace GStreamerDotNetTest
@@ -86,7 +87,20 @@ namespace GStreamerDotNetTest
                     {
                         case "1080p": cfg.Width = 1920; cfg.Height = 1080; break;
                         case "720p": cfg.Width = 1280; cfg.Height = 720; break;
-                        default: cfg.Width = 0; cfg.Height = 0; break;
+                        case "Input":
+                        default:
+                            if (cfg.MonitorIndex >= 0 && cfg.MonitorIndex < Forms.Screen.AllScreens.Length)
+                            {
+                                var bounds = Forms.Screen.AllScreens[cfg.MonitorIndex].Bounds;
+                                cfg.Width = bounds.Width;
+                                cfg.Height = bounds.Height;
+                            }
+                            else
+                            {
+                                cfg.Width = 0;
+                                cfg.Height = 0;
+                            }
+                            break;
                     }
                     int.TryParse(s.FrameRate.Text, out cfg.Framerate);
                     int.TryParse(s.Bitrate.Text, out cfg.BitrateKbps);

--- a/GstPlayer/GStreamerWrapper.cpp
+++ b/GstPlayer/GStreamerWrapper.cpp
@@ -78,10 +78,10 @@ namespace GStreamerWrapper {
         g_object_set(src,
             "monitor-index", config.MonitorIndex,
             "show-cursor", TRUE,
-            "left", config.CropX,
-            "top", config.CropY,
-            "width", config.CropW,
-            "height", config.CropH,
+            "crop-x", config.CropX,
+            "crop-y", config.CropY,
+            "crop-width", config.CropW,
+            "crop-height", config.CropH,
             NULL);
 
         std::ostringstream caps_str;

--- a/GstPlayer/ScreenCaptureServer.cpp
+++ b/GstPlayer/ScreenCaptureServer.cpp
@@ -76,6 +76,10 @@ static GstRTSPFilterResult force_client_disconnect(GstRTSPServer*, GstRTSPClient
 typedef struct _MyMediaFactory {
     GstRTSPMediaFactory parent;
     int monitor_index;
+    int crop_x;
+    int crop_y;
+    int crop_w;
+    int crop_h;
     int out_w, out_h;
     int fps;
     int v_bitrate_kbps;
@@ -121,6 +125,10 @@ static GstElement* my_media_factory_create_element(GstRTSPMediaFactory* factory,
     MyMediaFactory* self = (MyMediaFactory*)factory;
 
     const gint monitor_index = self->monitor_index;
+    const gint crop_x = self->crop_x;
+    const gint crop_y = self->crop_y;
+    const gint crop_w = self->crop_w;
+    const gint crop_h = self->crop_h;
     const gint out_w = (self->out_w & ~1);
     const gint out_h = (self->out_h & ~1);
     const gint fps = self->fps;
@@ -163,7 +171,14 @@ static GstElement* my_media_factory_create_element(GstRTSPMediaFactory* factory,
     gst_bin_add_many(GST_BIN(bin), vsrc, vd3d, vdown, vconv, tover, vconv2, vq1, venc, vparse, vcf, vq2, vpay, NULL);
 #endif
 
-    g_object_set(vsrc, "monitor-index", monitor_index, "show-cursor", TRUE, NULL);
+    g_object_set(vsrc,
+        "monitor-index", monitor_index,
+        "show-cursor", TRUE,
+        "crop-x", crop_x,
+        "crop-y", crop_y,
+        "crop-width", crop_w,
+        "crop-height", crop_h,
+        NULL);
 
     // GPU caps
     {
@@ -329,6 +344,10 @@ static void my_media_factory_init(MyMediaFactory * self) {
     self->overlay_text = g_strdup("");
     self->overlay_elem = NULL;
 #endif
+    self->crop_x = 0;
+    self->crop_y = 0;
+    self->crop_w = 0;
+    self->crop_h = 0;
 }
 
 static GstRTSPMediaFactory* create_factory_from_config(const StreamConfigNative& cfg) {
@@ -336,6 +355,10 @@ static GstRTSPMediaFactory* create_factory_from_config(const StreamConfigNative&
 
     MyMediaFactory* f = (MyMediaFactory*)g_object_new(my_media_factory_get_type(), NULL);
     f->monitor_index = cfg.monitor_index;
+    f->crop_x = cfg.crop_x;
+    f->crop_y = cfg.crop_y;
+    f->crop_w = cfg.crop_w;
+    f->crop_h = cfg.crop_h;
     f->out_w = cfg.width > 0 ? cfg.width : 1920;
     f->out_h = cfg.height > 0 ? cfg.height : 1200;
     f->fps = cfg.framerate > 0 ? cfg.framerate : 30;


### PR DESCRIPTION
## Summary
- use crop-x/crop-y/crop-width/crop-height for screen capture source
- include crop configuration in RTSP server pipeline
- choose input resolution based on selected monitor size

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bf81900ee8832f9dd5f80e096d442a