### PR TITLE
Remove WinForms dependency and set default stream options

### DIFF
--- a/GStreamerDotNetTest/DisplayHelper.cs
+++ b/GStreamerDotNetTest/DisplayHelper.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace GStreamerDotNetTest
+{
+    internal static class DisplayHelper
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RECT
+        {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+        }
+
+        private delegate bool MonitorEnumProc(IntPtr hMonitor, IntPtr hdcMonitor, ref RECT rect, IntPtr data);
+
+        [DllImport("user32.dll")]
+        private static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, MonitorEnumProc callback, IntPtr data);
+
+        public static bool TryGetMonitorSize(int index, out int width, out int height)
+        {
+            var rects = new List<RECT>();
+            EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero,
+                (hMonitor, hdc, ref RECT rect, IntPtr data) =>
+                {
+                    rects.Add(rect);
+                    return true;
+                }, IntPtr.Zero);
+
+            if (index >= 0 && index < rects.Count)
+            {
+                var r = rects[index];
+                width = r.Right - r.Left;
+                height = r.Bottom - r.Top;
+                return true;
+            }
+
+            width = height = 0;
+            return false;
+        }
+    }
+}
+

--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -16,7 +16,6 @@ using System.IO;
 using System.Security.Policy;
 using System.Text.RegularExpressions;
 using System.Windows.Controls;
-using Forms = System.Windows.Forms;
 
 
 namespace GStreamerDotNetTest
@@ -89,11 +88,10 @@ namespace GStreamerDotNetTest
                         case "720p": cfg.Width = 1280; cfg.Height = 720; break;
                         case "Input":
                         default:
-                            if (cfg.MonitorIndex >= 0 && cfg.MonitorIndex < Forms.Screen.AllScreens.Length)
+                            if (DisplayHelper.TryGetMonitorSize(cfg.MonitorIndex, out var w, out var h))
                             {
-                                var bounds = Forms.Screen.AllScreens[cfg.MonitorIndex].Bounds;
-                                cfg.Width = bounds.Width;
-                                cfg.Height = bounds.Height;
+                                cfg.Width = w;
+                                cfg.Height = h;
                             }
                             else
                             {
@@ -190,30 +188,47 @@ namespace GStreamerDotNetTest
             cropPanel.Children.Add(new Label { Content = "H" }); cropPanel.Children.Add(setting.CropH);
             root.Children.Add(LabeledControl("Crop:", cropPanel));
 
+            setting.Monitor.SelectionChanged += (s, e) =>
+            {
+                if (setting.Monitor.SelectedItem is string txt &&
+                    int.TryParse(txt, out int idx) &&
+                    DisplayHelper.TryGetMonitorSize(idx, out int mw, out int mh))
+                {
+                    setting.CropX.Text = "0";
+                    setting.CropY.Text = "0";
+                    setting.CropW.Text = mw.ToString();
+                    setting.CropH.Text = mh.ToString();
+                }
+            };
+            setting.Monitor.SelectedIndex = 0;
+
             setting.Resolution = new ComboBox();
             setting.Resolution.Items.Add("Input");
             setting.Resolution.Items.Add("1080p");
             setting.Resolution.Items.Add("720p");
+            setting.Resolution.SelectedIndex = 0;
             root.Children.Add(LabeledControl("Resolution:", setting.Resolution));
 
-            setting.FrameRate = new TextBox { Width = 60 };
+            setting.FrameRate = new TextBox { Width = 60, Text = "30" };
             root.Children.Add(LabeledControl("Frame rate:", setting.FrameRate));
 
-            setting.Bitrate = new TextBox { Width = 60 };
+            setting.Bitrate = new TextBox { Width = 60, Text = "6000" };
             root.Children.Add(LabeledControl("Bitrate:", setting.Bitrate));
 
             setting.BitrateControl = new ComboBox();
             setting.BitrateControl.Items.Add("CBR");
             setting.BitrateControl.Items.Add("VBR");
+            setting.BitrateControl.SelectedIndex = 0;
             root.Children.Add(LabeledControl("Bitrate Control:", setting.BitrateControl));
 
-            setting.Keyframe = new TextBox { Width = 60 };
+            setting.Keyframe = new TextBox { Width = 60, Text = "1" };
             root.Children.Add(LabeledControl("Keyframe Interval:", setting.Keyframe));
 
             setting.Profile = new ComboBox();
             setting.Profile.Items.Add("main");
             setting.Profile.Items.Add("baseline");
             setting.Profile.Items.Add("high");
+            setting.Profile.SelectedItem = "baseline";
             root.Children.Add(LabeledControl("Profile:", setting.Profile));
 
             tab.Content = root;


### PR DESCRIPTION
## Summary
- obtain monitor sizes via Win32 API instead of WinForms
- set sensible defaults for streaming options

## Testing
- `dotnet build StreamerGst.sln` *(fails: The imported project "/Microsoft.Cpp.Default.props" was not found. / .NETFramework,Version=v4.8 reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_b_68bf8500ac24832f99a0235e68dd7a28