### PR TITLE
Limit monitor buttons to available displays and play full-screen

### DIFF
--- a/GStreamerDotNetTest/DisplayHelper.cs
+++ b/GStreamerDotNetTest/DisplayHelper.cs
@@ -20,6 +20,18 @@ namespace GStreamerDotNetTest
         [DllImport("user32.dll")]
         private static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, MonitorEnumProc callback, IntPtr data);
 
+        public static int GetMonitorCount()
+        {
+            int count = 0;
+            EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero,
+                (IntPtr hMonitor, IntPtr hdc, ref RECT rect, IntPtr data) =>
+                {
+                    count++;
+                    return true;
+                }, IntPtr.Zero);
+            return count;
+        }
+
         public static bool TryGetMonitorSize(int index, out int width, out int height)
         {
             var rects = new List<RECT>();

--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -68,6 +68,13 @@ namespace GStreamerDotNetTest
 
                 // HwndHost가 제공하는 창 핸들(Handle)을 GstPlayer에 전달
                 _player = new GstPlayer(_videoHost.Handle);
+
+                int monitorCount = DisplayHelper.GetMonitorCount();
+                var buttons = new[] { btnM1Play, btnM2Play, btnM3Play, btnM4Play };
+                for (int i = 0; i < buttons.Length; i++)
+                {
+                    buttons[i].Visibility = i < monitorCount ? Visibility.Visible : Visibility.Collapsed;
+                }
             }
 
             private StreamConfig[] CollectStreamConfigs()
@@ -141,9 +148,23 @@ namespace GStreamerDotNetTest
                     int idx = int.Parse(match.Groups[1].Value);
                     monitorIndex = Math.Max(0, idx - 1);
                 }
-                if (_configs != null && monitorIndex < _configs.Length)
+
+                if (DisplayHelper.TryGetMonitorSize(monitorIndex, out int width, out int height))
                 {
-                    _player?.StartScreenCapture(_configs[monitorIndex]);
+                    var cfg = new StreamConfig
+                    {
+                        MonitorIndex = monitorIndex,
+                        CropX = 0,
+                        CropY = 0,
+                        CropW = width,
+                        CropH = height,
+                        Width = width,
+                        Height = height,
+                        Framerate = 30,
+                        BitrateKbps = 6000,
+                        KeyframeInterval = 1
+                    };
+                    _player?.StartScreenCapture(cfg);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Show monitor play buttons only up to the number of connected monitors
- Always capture the full screen of the selected monitor when a monitor play button is pressed

## Testing
- `dotnet build GStreamerDotNetTest/StreamerDotNet.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bfcc7711dc832f806d2edf691cf40e