### PR TITLE
Add audio and hardware acceleration settings

### DIFF
--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ namespace GStreamerDotNetTest
             private GstPlayer _player;
             private GstVideoHost _videoHost;
             private StreamConfig[] _configs = Array.Empty<StreamConfig>();
+            private string[] _audioDevices = Array.Empty<string>();
 
 
             private class StreamSetting
@@ -38,6 +39,9 @@ namespace GStreamerDotNetTest
                 public TextBox FrameRate, Bitrate, Keyframe;
                 public ComboBox BitrateControl;
                 public ComboBox Profile;
+                public ComboBox AudioEnable;
+                public ComboBox AudioDevice;
+                public ComboBox HwAccel;
                 public TabItem Tab;
             }
 
@@ -68,6 +72,7 @@ namespace GStreamerDotNetTest
 
                 // HwndHost가 제공하는 창 핸들(Handle)을 GstPlayer에 전달
                 _player = new GstPlayer(_videoHost.Handle);
+                _audioDevices = GstPlayer.GetAudioDevices();
 
                 int monitorCount = DisplayHelper.GetMonitorCount();
                 var buttons = new[] { btnM1Play, btnM2Play, btnM3Play, btnM4Play };
@@ -111,6 +116,9 @@ namespace GStreamerDotNetTest
                     int.TryParse(s.FrameRate.Text, out cfg.Framerate);
                     int.TryParse(s.Bitrate.Text, out cfg.BitrateKbps);
                     int.TryParse(s.Keyframe.Text, out cfg.KeyframeInterval);
+                    cfg.EnableAudio = s.AudioEnable.SelectedIndex == 0;
+                    cfg.AudioDevice = s.AudioDevice.SelectedItem as string;
+                    cfg.EnableHardwareAccel = s.HwAccel.SelectedIndex == 0;
                     list.Add(cfg);
                 }
                 return list.ToArray();
@@ -252,6 +260,23 @@ namespace GStreamerDotNetTest
             setting.Profile.Items.Add("high");
             setting.Profile.SelectedItem = "baseline";
             root.Children.Add(LabeledControl("Profile:", setting.Profile));
+
+            setting.AudioEnable = new ComboBox();
+            setting.AudioEnable.Items.Add("Use");
+            setting.AudioEnable.Items.Add("Don't use");
+            setting.AudioEnable.SelectedIndex = 0;
+            root.Children.Add(LabeledControl("Audio Stream:", setting.AudioEnable));
+
+            setting.AudioDevice = new ComboBox();
+            foreach (var dev in _audioDevices) setting.AudioDevice.Items.Add(dev);
+            if (setting.AudioDevice.Items.Count > 0) setting.AudioDevice.SelectedIndex = 0;
+            root.Children.Add(LabeledControl("Audio Device:", setting.AudioDevice));
+
+            setting.HwAccel = new ComboBox();
+            setting.HwAccel.Items.Add("Use");
+            setting.HwAccel.Items.Add("Don't use");
+            setting.HwAccel.SelectedIndex = 0;
+            root.Children.Add(LabeledControl("HW Acceleration:", setting.HwAccel));
 
             tab.Content = root;
             setting.Tab = tab;

--- a/GstPlayer/GStreamerWrapper.cpp
+++ b/GstPlayer/GStreamerWrapper.cpp
@@ -4,6 +4,9 @@
 
 #include <vector>
 #include <sstream>
+#include <msclr/marshal_cppstd.h>
+#include <gst/gstdevicemonitor.h>
+#include <gst/gstdevice.h>
 
 // 필요한 .NET 네임스페이스 추가
 using namespace System::Runtime::InteropServices; // GCHandle을 위해 추가
@@ -43,6 +46,29 @@ namespace GStreamerWrapper {
     {
         StopScreenCaptureRtspServer();
         gst_deinit();
+    }
+
+    array<String^>^ GstPlayer::GetAudioDevices()
+    {
+        std::vector<String^> devices;
+        GstDeviceMonitor* mon = gst_device_monitor_new();
+        GstCaps* caps = gst_caps_new_empty_simple("audio/x-raw");
+        gst_device_monitor_add_filter(mon, "Audio/Source", caps);
+        gst_caps_unref(caps);
+        gst_device_monitor_start(mon);
+        GList* devs = gst_device_monitor_get_devices(mon);
+        for (GList* l = devs; l; l = l->next) {
+            GstDevice* d = GST_DEVICE(l->data);
+            const gchar* name = gst_device_get_display_name(d);
+            if (name) devices.push_back(gcnew String(name));
+            gst_object_unref(d);
+        }
+        g_list_free(devs);
+        gst_device_monitor_stop(mon);
+        gst_object_unref(mon);
+        array<String^>^ arr = gcnew array<String^>((int)devices.size());
+        for (size_t i = 0; i < devices.size(); ++i) arr[i] = devices[i];
+        return arr;
     }
 
     GstPlayer::GstPlayer(IntPtr windowHandle) : pipeline(nullptr)
@@ -127,6 +153,10 @@ namespace GStreamerWrapper {
             ncfg.framerate = cfg.Framerate;
             ncfg.bitrate_kbps = cfg.BitrateKbps;
             ncfg.keyframe_interval = cfg.KeyframeInterval;
+            ncfg.enable_audio = cfg.EnableAudio;
+            if (cfg.AudioDevice != nullptr)
+                ncfg.audio_device = msclr::interop::marshal_as<std::string>(cfg.AudioDevice);
+            ncfg.enable_hw_accel = cfg.EnableHardwareAccel;
             nativeConfigs.push_back(ncfg);
         }
 

--- a/GstPlayer/GStreamerWrapper.h
+++ b/GstPlayer/GStreamerWrapper.h
@@ -21,6 +21,9 @@ namespace GStreamerWrapper {
         int Framerate;
         int BitrateKbps;
         int KeyframeInterval;
+        bool EnableAudio;
+        String^ AudioDevice;
+        bool EnableHardwareAccel;
     };
 
     public ref class GstPlayer
@@ -44,5 +47,6 @@ namespace GStreamerWrapper {
 
         static void Initialize();
         static void Deinitialize();
+        static array<String^>^ GetAudioDevices();
     };
 }

--- a/GstPlayer/ScreenCaptureServer.cpp
+++ b/GstPlayer/ScreenCaptureServer.cpp
@@ -85,6 +85,8 @@ typedef struct _MyMediaFactory {
     int v_bitrate_kbps;
     int a_bitrate_bps;
     gboolean enable_audio;
+    gchar* audio_device;
+    gboolean use_hw_accel;
 
 #ifdef TextOveray
     // 텍스트 오버레이 상태 (오버레이가 켜진 빌드에서만 포함)
@@ -149,7 +151,8 @@ static GstElement* my_media_factory_create_element(GstRTSPMediaFactory* factory,
 #endif
 
     GstElement* vq1 = gst_element_factory_make("queue", "vqueue1");
-    GstElement* venc = gst_element_factory_make("x264enc", "venc");
+    const char* enc_name = self->use_hw_accel ? "d3d11h264enc" : "x264enc";
+    GstElement* venc = gst_element_factory_make(enc_name, "venc");
     GstElement* vparse = gst_element_factory_make("h264parse", "vparse");
     GstElement* vcf = gst_element_factory_make("capsfilter", "vpaycaps");
     GstElement* vq2 = gst_element_factory_make("queue", "vqueue2");
@@ -228,32 +231,36 @@ static GstElement* my_media_factory_create_element(GstRTSPMediaFactory* factory,
     static const char* kH264Profile = "high";
     static const char* kH264Level = "5";
 
-    g_object_set(venc,
-        "bitrate", v_kbps,
-        "key-int-max", fps,
-        "b-adapt", 0,
-        "bframes", 0,
-        "ref", 1,
-        "byte-stream", TRUE,
-        "speed-preset", 1,
-        "tune", 0x04,
-        NULL);
+    if (self->use_hw_accel) {
+        g_object_set(venc, "bitrate", v_kbps, NULL);
+    } else {
+        g_object_set(venc,
+            "bitrate", v_kbps,
+            "key-int-max", fps,
+            "b-adapt", 0,
+            "bframes", 0,
+            "ref", 1,
+            "byte-stream", TRUE,
+            "speed-preset", 1,
+            "tune", 0x04,
+            NULL);
 
-    {
-        std::ostringstream opt;
-        opt << "level=" << kH264Level << ":vbv-maxrate=" << v_kbps << ":vbv-bufsize=" << (v_kbps * 2);
-        g_object_set(venc, "option-string", opt.str().c_str(), NULL);
-        g_object_set(venc, "nal-hrd", 2, "vbv-buf-capacity", 1000, NULL);
-    }
+        {
+            std::ostringstream opt;
+            opt << "level=" << kH264Level << ":vbv-maxrate=" << v_kbps << ":vbv-bufsize=" << (v_kbps * 2);
+            g_object_set(venc, "option-string", opt.str().c_str(), NULL);
+            g_object_set(venc, "nal-hrd", 2, "vbv-buf-capacity", 1000, NULL);
+        }
 
-    if (!strcmp(kH264Profile, "baseline") || !strcmp(kH264Profile, "constrained-baseline")) {
-        g_object_set(venc, "cabac", FALSE, "dct8x8", FALSE, "bframes", 0, "ref", 1, NULL);
-    }
-    else if (!strcmp(kH264Profile, "main")) {
-        g_object_set(venc, "cabac", TRUE, "dct8x8", FALSE, NULL);
-    }
-    else if (!strcmp(kH264Profile, "high")) {
-        g_object_set(venc, "cabac", TRUE, "dct8x8", TRUE, NULL);
+        if (!strcmp(kH264Profile, "baseline") || !strcmp(kH264Profile, "constrained-baseline")) {
+            g_object_set(venc, "cabac", FALSE, "dct8x8", FALSE, "bframes", 0, "ref", 1, NULL);
+        }
+        else if (!strcmp(kH264Profile, "main")) {
+            g_object_set(venc, "cabac", TRUE, "dct8x8", FALSE, NULL);
+        }
+        else if (!strcmp(kH264Profile, "high")) {
+            g_object_set(venc, "cabac", TRUE, "dct8x8", TRUE, NULL);
+        }
     }
 
     {
@@ -293,6 +300,8 @@ static GstElement* my_media_factory_create_element(GstRTSPMediaFactory* factory,
             gst_bin_add_many(GST_BIN(bin), asrc, aq1, aconv, ares, acapsf, arate, aq2, aenc, apay, NULL);
 
             g_object_set(asrc, "loopback", TRUE, "do-timestamp", TRUE, NULL);
+            if (self->audio_device)
+                g_object_set(asrc, "device-name", self->audio_device, NULL);
             g_object_set(aq1, "leaky", 2, "max-size-buffers", 2, "max-size-bytes", 0, "max-size-time", (gint64)200000000, NULL);
             g_object_set(aq2, "leaky", 2, "max-size-buffers", 2, "max-size-bytes", 0, "max-size-time", (gint64)200000000, NULL);
 
@@ -329,6 +338,10 @@ static void my_media_factory_finalize(GObject * object) {
         self->overlay_text = NULL;
     }
 #endif
+    if (self->audio_device) {
+        g_free(self->audio_device);
+        self->audio_device = NULL;
+    }
     G_OBJECT_CLASS(my_media_factory_parent_class)->finalize(object);
 }
 
@@ -348,12 +361,12 @@ static void my_media_factory_init(MyMediaFactory * self) {
     self->crop_y = 0;
     self->crop_w = 0;
     self->crop_h = 0;
+    self->audio_device = NULL;
+    self->use_hw_accel = FALSE;
 }
 
 static GstRTSPMediaFactory* create_factory_from_config(const StreamConfigNative& cfg,
                                                       int stream_index) {
-    const bool ENABLE_AUDIO = true;
-
     MyMediaFactory* f = (MyMediaFactory*)g_object_new(my_media_factory_get_type(), NULL);
     f->monitor_index = cfg.monitor_index;
     f->crop_x = cfg.crop_x;
@@ -365,7 +378,10 @@ static GstRTSPMediaFactory* create_factory_from_config(const StreamConfigNative&
     f->fps = cfg.framerate > 0 ? cfg.framerate : 30;
     f->v_bitrate_kbps = cfg.bitrate_kbps > 0 ? cfg.bitrate_kbps : 8000;
     f->a_bitrate_bps = 128000;
-    f->enable_audio = ENABLE_AUDIO;
+    f->enable_audio = cfg.enable_audio;
+    if (!cfg.audio_device.empty())
+        f->audio_device = g_strdup(cfg.audio_device.c_str());
+    f->use_hw_accel = cfg.enable_hw_accel;
 
 #ifdef TextOveray
     if (f->overlay_text) g_free(f->overlay_text);

--- a/GstPlayer/ScreenCaptureServer.h
+++ b/GstPlayer/ScreenCaptureServer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace GStreamerWrapper {
 
 // Stream configuration passed from the managed layer. This simple
@@ -16,6 +18,9 @@ struct StreamConfigNative {
     int framerate;
     int bitrate_kbps;
     int keyframe_interval;
+    bool enable_audio;
+    std::string audio_device;
+    bool enable_hw_accel;
 };
 
 // Starts the RTSP screen capture server on a background thread hosting


### PR DESCRIPTION
## Summary
- allow enabling/disabling audio streaming and selecting audio device
- expose hardware acceleration toggle for each stream
- pass new settings through wrapper to RTSP pipeline

## Testing
- `dotnet build StreamerGst.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c0d7062ad0832fbe87137d2f65356d