### PR TITLE
refactor pipeline to use encodebin for H.264

### DIFF
--- a/GstPlayer/ScreenCaptureServer.cpp
+++ b/GstPlayer/ScreenCaptureServer.cpp
@@ -1,5 +1,6 @@
 #include <gst/gst.h>
 #include <gst/rtsp-server/rtsp-server.h>
+#include <gst/pbutils/encoding-profile.h>
 #include <string>
 #include <vector>
 #include <sstream>
@@ -45,73 +46,6 @@ static std::thread g_server_thread;
 // 전방 선언
 static void SetOverlayText(RtspServerContext* ctx, int screen_index, const char* text);
 // ===== [ADD] 공용 프로퍼티 세터/인코더 선택 유틸 =====
-static inline gboolean has_prop(GstElement* e, const char* name) {
-    return e && g_object_class_find_property(G_OBJECT_GET_CLASS(e), name) != nullptr;
-}
-static inline void set_int_if(GstElement* e, const char* name, int v) {
-    if (has_prop(e, name)) g_object_set(e, name, v, NULL);
-}
-static inline void set_bool_if(GstElement* e, const char* name, gboolean v) {
-    if (has_prop(e, name)) g_object_set(e, name, v, NULL);
-}
-static inline void set_string_if(GstElement* e, const char* name, const char* v) {
-    if (has_prop(e, name)) g_object_set(e, name, v, NULL);
-}
-
-// H.264 하드웨어 인코더 후보들 중 "등록되어 있고(rank가 가장 높은)" 요소를 선택
-// ※ 필요시 후보 순서는 자유롭게 추가/조정 가능
-static const char* pick_best_hw_h264_encoder() {
-    struct Cand { const char* name; };
-    static const Cand candidates[] = {
-        {"d3d11h264enc"}, // DX11 기반
-        {"qsvh264enc"},   // Intel QuickSync
-        {"nvh264enc"},    // NVIDIA NVENC
-        {"amfh264enc"},   // AMD AMF
-        {"mfh264enc"},    // Media Foundation H264
-    };
-    const char* best = nullptr;
-    guint best_rank = 0;
-    for (const auto& c : candidates) {
-        GstElementFactory* f = gst_element_factory_find(c.name);
-        if (!f) continue;
-        guint r = gst_plugin_feature_get_rank(GST_PLUGIN_FEATURE(f));
-        if (!best || r > best_rank) {
-            best = c.name;
-            best_rank = r;
-        }
-        gst_object_unref(f);
-    }
-    return best; // nullptr이면 사용 가능한 HW 인코더 없음
-}
-
-// 인코더 공통 튜닝(존재하는 프로퍼티만 안전하게 세팅)
-// - v_kbps: kbps 기준
-// - keyint: 키프레임 간격 (GOP)
-// - fps   : 참고용(일부 인코더는 keyint=fps 형태로 사용)
-static void tune_h264_encoder(GstElement* enc, int v_kbps, int keyint, int /*fps*/) {
-    if (!enc) return;
-
-    // 비트레이트 (kbps/bps 혼용 대비: 여러 이름을 시도)
-    set_int_if(enc, "bitrate", v_kbps);                // 대부분 kbps
-    set_int_if(enc, "max-bitrate", v_kbps);
-    set_int_if(enc, "target-bitrate", v_kbps * 1000);  // 일부 bps
-
-    // 키프레임 간격/GOP
-    set_int_if(enc, "key-int-max", keyint); // x264enc
-    set_int_if(enc, "gop-size", keyint); // qsv/nvenc/d3d11 등
-    set_int_if(enc, "gop", keyint); // mf/amf 등
-
-    // 저지연/레이트컨트롤(있는 경우에만)
-    set_string_if(enc, "tune", "zerolatency"); // x264enc
-    set_bool_if(enc, "low-latency", TRUE);   // 일부 HW 인코더
-    set_string_if(enc, "rate-control", "cbr"); // qsv/nvenc/d3d11 일부
-    set_string_if(enc, "rc-mode", "cbr"); // amf 등
-
-    // H.264 스트림 포맷 관련
-    set_bool_if(enc, "byte-stream", TRUE);   // x264enc 등에만 적용됨
-    set_string_if(enc, "speed-preset", "ultrafast"); // x264enc
-    set_string_if(enc, "preset", "ultrafast"); // 일부 인코더는 preset 사용
-}
 
 // ===== 클라이언트 종료/로그 =====
 static void client_closed_callback(GstRTSPClient* client, gpointer user_data) {
@@ -199,7 +133,6 @@ static GstElement* my_media_factory_create_element(GstRTSPMediaFactory* factory,
     const gint out_w = (self->out_w & ~1);
     const gint out_h = (self->out_h & ~1);
     const gint fps = self->fps;
-    const gint v_kbps = self->v_bitrate_kbps;
     const gint a_bps = self->a_bitrate_bps;
 
     GstElement* bin = gst_bin_new(NULL);
@@ -209,48 +142,33 @@ static GstElement* my_media_factory_create_element(GstRTSPMediaFactory* factory,
     GstElement* vd3d = gst_element_factory_make("d3d11convert", "vd3d11conv");
     GstElement* tover = gst_element_factory_make("dwritetextoverlay", "overlay");
     GstElement* vd3d2 = gst_element_factory_make("d3d11convert", "vd3d11conv2");
-    GstElement* vdown = NULL; // CPU path when using non-D3D11 encoder
+    GstElement* vdown = NULL; // CPU path when using software encoder
     GstElement* vq1 = gst_element_factory_make("queue", "vqueue1");
-    // [CHANGE] 요구사항: HW ON이면 x264 제외 HW 인코더 중 랭크 최상 선택, HW OFF면 x264 고정
-    const char* enc_name = nullptr;
-    if (self->use_hw_accel) {
-        enc_name = pick_best_hw_h264_encoder(); // 없으면 nullptr
-        if (!enc_name) {
-            g_printerr("[warn] 사용 가능한 하드웨어 H.264 인코더가 없어 x264enc로 대체합니다.\n");
-            enc_name = "x264enc";
-        }
-        else {
-            g_print("[info] 선택된 하드웨어 H.264 인코더: %s\n", enc_name);
-        }
-    }
-    else {
-        enc_name = "x264enc";
-    }
-    GstElement* venc = gst_element_factory_make(enc_name, "venc");
-    if (!venc) {
-        g_printerr("인코더(%s) 생성 실패\n", enc_name);
-        if (bin) gst_object_unref(bin);
-        return NULL;
-    }
-    const gboolean use_d3d11_encoder = g_str_has_prefix(enc_name, "d3d11");
-    if (!use_d3d11_encoder) {
-        vdown = gst_element_factory_make("d3d11download", "vdown");
-    }
+    GstElement* vencbin = gst_element_factory_make("encodebin", "vencbin");
     GstElement* vparse = gst_element_factory_make("h264parse", "vparse");
     GstElement* vcf = gst_element_factory_make("capsfilter", "vpaycaps");
     GstElement* vq2 = gst_element_factory_make("queue", "vqueue2");
     GstElement* vpay = gst_element_factory_make("rtph264pay", "pay0");
 
-    if (!vsrc || !vd3d || !tover || !vd3d2 || (!use_d3d11_encoder && !vdown) || !vq1 || !venc || !vparse || !vcf || !vq2 || !vpay) {
+    if (self->use_hw_accel) {
+        GstPluginFeature* f = gst_registry_find_feature(gst_registry_get(), "x264enc", GST_TYPE_ELEMENT_FACTORY);
+        if (f) { gst_plugin_feature_set_rank(f, 0); gst_object_unref(f); }
+    } else {
+        vdown = gst_element_factory_make("d3d11download", "vdown");
+        GstPluginFeature* f = gst_registry_find_feature(gst_registry_get(), "x264enc", GST_TYPE_ELEMENT_FACTORY);
+        if (f) { gst_plugin_feature_set_rank(f, GST_RANK_PRIMARY + 100); gst_object_unref(f); }
+    }
+
+    if (!vsrc || !vd3d || !tover || !vd3d2 || (!self->use_hw_accel && !vdown) || !vq1 || !vencbin || !vparse || !vcf || !vq2 || !vpay) {
         g_printerr("비디오 요소 생성 실패\n");
         if (bin) gst_object_unref(bin);
         return NULL;
     }
 
-    if (use_d3d11_encoder)
-        gst_bin_add_many(GST_BIN(bin), vsrc, vd3d, tover, vd3d2, vq1, venc, vparse, vcf, vq2, vpay, NULL);
+    if (self->use_hw_accel)
+        gst_bin_add_many(GST_BIN(bin), vsrc, vd3d, tover, vd3d2, vq1, vencbin, vparse, vcf, vq2, vpay, NULL);
     else
-        gst_bin_add_many(GST_BIN(bin), vsrc, vd3d, tover, vd3d2, vdown, vq1, venc, vparse, vcf, vq2, vpay, NULL);
+        gst_bin_add_many(GST_BIN(bin), vsrc, vd3d, tover, vd3d2, vdown, vq1, vencbin, vparse, vcf, vq2, vpay, NULL);
 
     g_object_set(vsrc,
         "monitor-index", monitor_index,
@@ -294,7 +212,7 @@ static GstElement* my_media_factory_create_element(GstRTSPMediaFactory* factory,
         css_gpu_nv12 << "video/x-raw(memory:D3D11Memory),format=NV12," <<
             "width=" << out_w << ",height=" << out_h <<
             ",framerate=" << fps << "/1,pixel-aspect-ratio=1/1";
-        if (use_d3d11_encoder) {
+        if (self->use_hw_accel) {
             if (!link_ok(vd3d2, vq1, caps_from(css_gpu_nv12.str()))) return bin;
         } else {
             if (!link_ok(vd3d2, vdown, caps_from(css_gpu_nv12.str()))) return bin;
@@ -303,27 +221,6 @@ static GstElement* my_media_factory_create_element(GstRTSPMediaFactory* factory,
     }
 
     static const char* kH264Profile = "high";
-    static const char* kH264Level = "5";
-
-    // [CHANGE] 공통 튜닝(있는 프로퍼티만 세팅) + x264 특성은 자동으로 감지되어 적용
-    const int keyint = (self->keyint > 0) ? self->keyint : fps;
-    tune_h264_encoder(venc, v_kbps, keyint, fps);
-
-    // (선택) x264 전용 추가 옵션을 더 주고 싶다면 has_prop로 감싸서 세팅
-    if (g_strcmp0(enc_name, "x264enc") == 0) {
-        // 예: 프로파일/레벨/HRD/버퍼 등
-        set_string_if(venc, "option-string", ("level=" + std::string(kH264Level) +
-            ":vbv-maxrate=" + std::to_string(v_kbps) +
-            ":vbv-bufsize=" + std::to_string(v_kbps * 2)).c_str());
-        set_int_if(venc, "nal-hrd", 2);
-        set_int_if(venc, "vbv-buf-capacity", 1000);
-        set_int_if(venc, "b-adapt", 0);
-        set_int_if(venc, "bframes", 0);
-        set_int_if(venc, "ref", 1);
-        // speed-preset, tune, byte-stream 등은 tune_h264_encoder에서 이미 안전 적용
-    }
-
-
     {
         std::ostringstream css;
         css << "video/x-h264,stream-format=byte-stream,alignment=au," <<
@@ -333,14 +230,26 @@ static GstElement* my_media_factory_create_element(GstRTSPMediaFactory* factory,
         gst_caps_unref(paycaps);
     }
 
+    GstCaps* restrict_caps = gst_caps_new_simple("video/x-raw",
+        "width", G_TYPE_INT, out_w,
+        "height", G_TYPE_INT, out_h,
+        "framerate", GST_TYPE_FRACTION, fps, 1,
+        NULL);
+    GstCaps* h264_caps = gst_caps_new_simple("video/x-h264", NULL);
+    GstEncodingVideoProfile* vprof = gst_encoding_video_profile_new(h264_caps, restrict_caps, NULL, 0);
+    gst_caps_unref(h264_caps);
+    gst_caps_unref(restrict_caps);
+    g_object_set(vencbin, "profile", vprof, NULL);
+    gst_encoding_profile_unref(vprof);
+
     g_object_set(vq1, "leaky", 2, "max-size-buffers", 2, "max-size-bytes", 0, "max-size-time", 0, NULL);
     g_object_set(vq2, "leaky", 2, "max-size-buffers", 2, "max-size-bytes", 0, "max-size-time", 0, NULL);
 
     g_object_set(vparse, "config-interval", 1, NULL);
     g_object_set(vpay, "pt", 96, "config-interval", 1, "mtu", 1200, NULL);
-    if (!link_ok(vq1, venc)) return bin;
+    if (!link_ok(vq1, vencbin)) return bin;
 
-    if (!link_ok(venc, vparse) ||
+    if (!link_ok(vencbin, vparse) ||
         !link_ok(vparse, vcf) || !link_ok(vcf, vq2) || !link_ok(vq2, vpay))
         return bin;
 


### PR DESCRIPTION
## Summary
- simplify screen capture pipeline by replacing manual encoder selection with encodebin
- enforce H.264 via encoding profile and adjust x264 ranking based on hardware acceleration

## Testing
- `dotnet build` *(fails: The imported project "/Microsoft.Cpp.Default.props" was not found and .NET Framework reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c1287add4c832fa5ced7d11b872d50