### PR TITLE
Fix IServiceProvider ambiguity by scoping System namespace

### DIFF
--- a/GstPlayer/GStreamerWrapper.cpp
+++ b/GstPlayer/GStreamerWrapper.cpp
@@ -12,11 +12,6 @@
 #include <Functiondiscoverykeys_devpkey.h>
 #include <Propidl.h>
 
-// 필요한 .NET 네임스페이스 추가
-using namespace System::Runtime::InteropServices; // GCHandle을 위해 추가
-using namespace System::Diagnostics;             // Debug 클래스를 위해 추가
-using namespace System::Collections::Generic;
-
 #pragma comment(lib, "gstreamer-1.0.lib")
 #pragma comment(lib, "gstvideo-1.0.lib")
 #pragma comment(lib, "gobject-2.0.lib")
@@ -24,6 +19,12 @@ using namespace System::Collections::Generic;
 #pragma comment(lib, "ole32.lib")
 
 namespace GStreamerWrapper {
+
+    // 필요한 .NET 네임스페이스 추가
+    using namespace System;
+    using namespace System::Runtime::InteropServices; // GCHandle을 위해 추가
+    using namespace System::Diagnostics;             // Debug 클래스를 위해 추가
+    using namespace System::Collections::Generic;
 
     void GstPlayer::Initialize()
     {

--- a/GstPlayer/GStreamerWrapper.h
+++ b/GstPlayer/GStreamerWrapper.h
@@ -4,10 +4,11 @@
 #include <gst/video/videooverlay.h>
 #include <vcclr.h>
 #include <Windows.h>
-using namespace System;
-using namespace System::Runtime::InteropServices; // for GCHandle
 
 namespace GStreamerWrapper {
+
+    using namespace System;
+    using namespace System::Runtime::InteropServices; // for GCHandle
 
     public value struct StreamConfig
     {


### PR DESCRIPTION
## Summary
- move the System namespace using directives inside GStreamerWrapper to avoid leaking .NET types globally
- ensure the C++/CLI wrapper still accesses managed types while preventing name clashes with Windows headers

## Testing
- not run (Windows-specific build tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68cb6260eff4832fb9a569e6684be9b2