### PR TITLE
Adjust multicast interface configuration

### DIFF
--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -29,6 +29,9 @@ namespace GStreamerDotNetTest
             public ComboBox AudioDevice;
             public ComboBox HwAccel;
             public ComboBox OsdEnable;
+            public ComboBox MultiCastEnable;
+            public TextBox MultiCastIp;
+            public TextBox MultiCastInterface;
             public TabItem Tab;
         }
 
@@ -115,7 +118,9 @@ namespace GStreamerDotNetTest
                         EnableMultiCast = false,
                         BitrateControl = "CBR",
                         Profile = "high",
-                        OsdText = $"Screen {i + 1}"
+                        OsdText = $"Screen {i + 1}",
+                        MultiCastIP = string.Empty,
+                        MultiCastInterface = string.Empty
                     };
                     list.Add(cfg);
                 }
@@ -141,7 +146,9 @@ namespace GStreamerDotNetTest
                         BitrateControl = "CBR",
                         EnableMultiCast = false,
                         Profile = "baseline",
-                        OsdText = $"Screen {i + 1}"
+                        OsdText = $"Screen {i + 1}",
+                        MultiCastIP = string.Empty,
+                        MultiCastInterface = string.Empty
                     };
                     list.Add(cfg);
                 }
@@ -240,6 +247,19 @@ namespace GStreamerDotNetTest
 
                 cfg.EnableHardwareAccel = s.HwAccel.SelectedIndex == 0;
                 cfg.EnableOsd = s.OsdEnable.SelectedIndex == 0;
+                cfg.EnableMultiCast = (s.MultiCastEnable != null && s.MultiCastEnable.SelectedIndex == 1);
+
+                if (s.MultiCastIp != null)
+                {
+                    cfg.MultiCastIP = s.MultiCastIp.Text.Trim();
+                    if (string.IsNullOrWhiteSpace(cfg.MultiCastIP)) cfg.MultiCastIP = null;
+                }
+
+                if (s.MultiCastInterface != null)
+                {
+                    cfg.MultiCastInterface = s.MultiCastInterface.Text.Trim();
+                    if (string.IsNullOrWhiteSpace(cfg.MultiCastInterface)) cfg.MultiCastInterface = null;
+                }
 
                 list.Add(cfg);
             }
@@ -421,6 +441,18 @@ namespace GStreamerDotNetTest
             setting.OsdEnable.Items.Add("Don't use");
             setting.OsdEnable.SelectedIndex = 0;
             root.Children.Add(LabeledControl("OSD:", setting.OsdEnable));
+
+            setting.MultiCastEnable = new ComboBox();
+            setting.MultiCastEnable.Items.Add("Disable");
+            setting.MultiCastEnable.Items.Add("Enable");
+            setting.MultiCastEnable.SelectedIndex = 0;
+            root.Children.Add(LabeledControl("Multicast:", setting.MultiCastEnable));
+
+            setting.MultiCastIp = new TextBox { Width = 150 };
+            root.Children.Add(LabeledControl("Multicast IP:", setting.MultiCastIp));
+
+            setting.MultiCastInterface = new TextBox { Width = 150 };
+            root.Children.Add(LabeledControl("Multicast Interface:", setting.MultiCastInterface));
 
             tab.Content = root;
             setting.Tab = tab;

--- a/GstPlayer/GStreamerWrapper.cpp
+++ b/GstPlayer/GStreamerWrapper.cpp
@@ -261,6 +261,8 @@ namespace GStreamerWrapper {
                  ncfg.overlay_text = msclr::interop::marshal_as<std::string>(cfg.OsdText);
             if (cfg.MultiCastIP != nullptr)
                 ncfg.multicast_ip = msclr::interop::marshal_as<std::string>(cfg.MultiCastIP);
+            if (cfg.MultiCastInterface != nullptr)
+                ncfg.multicast_iface = msclr::interop::marshal_as<std::string>(cfg.MultiCastInterface);
             nativeConfigs.push_back(ncfg);
         }
 

--- a/GstPlayer/GStreamerWrapper.h
+++ b/GstPlayer/GStreamerWrapper.h
@@ -32,6 +32,7 @@ namespace GStreamerWrapper {
         String^ Profile;
         String^ OsdText;
         String^ MultiCastIP;
+        String^ MultiCastInterface;
     };
 
     public ref class GstPlayer

--- a/GstPlayer/ScreenCaptureServer.cpp
+++ b/GstPlayer/ScreenCaptureServer.cpp
@@ -686,6 +686,7 @@ namespace GStreamerWrapper {
         if (self->audio_device) { g_free(self->audio_device);    self->audio_device = NULL; }
         if (self->bitrate_control) { g_free(self->bitrate_control); self->bitrate_control = NULL; }
         if (self->profile) { g_free(self->profile);         self->profile = NULL; }
+        if (self->multicast_ip) { g_free(self->multicast_ip);   self->multicast_ip = NULL; }
         G_OBJECT_CLASS(my_media_factory_parent_class)->finalize(object);
     }
     static void my_media_factory_class_init(MyMediaFactoryClass* klass) {
@@ -705,6 +706,7 @@ namespace GStreamerWrapper {
         self->keyint = 0;
         self->bitrate_control = g_strdup("CBR");
         self->profile = g_strdup("high");
+        self->multicast_ip = NULL;
     }
 
     /* ---------- factory build / per-stream server ---------- */
@@ -749,32 +751,36 @@ namespace GStreamerWrapper {
 
         // 프로토콜/멀티캐스트 (운영 정책에 따라 조정)
         if (f->enable_multicast) {
-            gst_rtsp_media_factory_set_protocols(GST_RTSP_MEDIA_FACTORY(f),
-                (GST_RTSP_LOWER_TRANS_UDP_MCAST));
-              gst_rtsp_media_factory_set_multicast_iface(GST_RTSP_MEDIA_FACTORY(f), g_server_ip.c_str());
-        
+            gst_rtsp_media_factory_set_protocols(
+                GST_RTSP_MEDIA_FACTORY(f), GST_RTSP_LOWER_TRANS_UDP_MCAST);
+
+            if (!cfg.multicast_iface.empty()) {
+                gst_rtsp_media_factory_set_multicast_iface(
+                    GST_RTSP_MEDIA_FACTORY(f), cfg.multicast_iface.c_str());
+            }
 
             // 멀티캐스트 주소/포트 풀 (예시: 239.255.10.(11+N), base_port=15000+N*20)
-        const int base_octet = 11 + stream_index_1based;
-        const int base_port = 15000 + stream_index_1based * 20;
+            const int base_octet = 11 + stream_index_1based;
+            const int base_port = 15000 + stream_index_1based * 20;
 
-
-        if (!cfg.multicast_ip.empty())
-            f->multicast_ip = g_strdup(cfg.multicast_ip.c_str());
-        else {
-            std::ostringstream def; def<< "239.255.10." << base_octet;
-            f->multicast_ip = g_strdup(def.str().c_str());
-        }
-		std::istringstream ip(f->multicast_ip);
-        GstRTSPAddressPool* pool = gst_rtsp_address_pool_new();
-        gst_rtsp_address_pool_add_range(pool, ip.str().c_str(), ip.str().c_str(), base_port, base_port + 19, 16);
-        gst_rtsp_media_factory_set_address_pool(GST_RTSP_MEDIA_FACTORY(f), pool);
-        g_object_unref(pool);
+            if (!cfg.multicast_ip.empty())
+                f->multicast_ip = g_strdup(cfg.multicast_ip.c_str());
+            else {
+                std::ostringstream def;
+                def << "239.255.10." << base_octet;
+                f->multicast_ip = g_strdup(def.str().c_str());
+            }
+            std::istringstream ip(f->multicast_ip);
+            GstRTSPAddressPool* pool = gst_rtsp_address_pool_new();
+            gst_rtsp_address_pool_add_range(pool, ip.str().c_str(), ip.str().c_str(),
+                                            base_port, base_port + 19, 16);
+            gst_rtsp_media_factory_set_address_pool(GST_RTSP_MEDIA_FACTORY(f), pool);
+            g_object_unref(pool);
         }
         else {
             gst_rtsp_media_factory_set_protocols(GST_RTSP_MEDIA_FACTORY(f),
                (GstRTSPLowerTrans) (GST_RTSP_LOWER_TRANS_UDP | GST_RTSP_LOWER_TRANS_TCP));
-  
+
         }
       
 

--- a/GstPlayer/ScreenCaptureServer.h
+++ b/GstPlayer/ScreenCaptureServer.h
@@ -28,6 +28,7 @@ struct StreamConfigNative {
     std::string profile;
     std::string overlay_text;
     std::string multicast_ip;
+    std::string multicast_iface;
 };
 
 // Starts the RTSP screen capture server on a background thread hosting


### PR DESCRIPTION
## Summary
- add multicast interface fields through the C# UI, managed wrapper, and native config so multicast streams can target a specific network interface
- update the RTSP media factory to only set the multicast interface when provided and release stored multicast IP strings to avoid leaks

## Testing
- not run (Windows-specific project)


------
https://chatgpt.com/codex/tasks/task_b_68cd07db8d08832fa4c3e99329da4e52