### PR TITLE
Add worker process for pipeline creation

### DIFF
--- a/GstPlayer/GStreamerWrapper.cpp
+++ b/GstPlayer/GStreamerWrapper.cpp
@@ -27,6 +27,7 @@ namespace GStreamerWrapper
     using namespace System::Diagnostics;             // Debug 클래스를 위해 추가
     using namespace System::Collections::Generic;
     using namespace System::Text;
+    using namespace System::IO;
 
     // 기본값: 폴백 OFF (GstDeviceMonitor는 플러그인/드라이버 AV 가능성)
     static bool g_useGstDeviceMonitorFallback = false;
@@ -243,6 +244,61 @@ namespace GStreamerWrapper
         g_useGstDeviceMonitorFallback = enable;
     }
 
+    void GstPlayer::StopWorker()
+    {
+        try
+        {
+            if (workerProcess != nullptr && !workerProcess->HasExited)
+            {
+                workerProcess->Kill();
+                workerProcess->WaitForExit(2000);
+            }
+        }
+        catch (Exception ^ex)
+        {
+            Debug::WriteLine("[GstWorker] failed to stop: " + ex->Message);
+        }
+
+        workerProcess = nullptr;
+
+        try
+        {
+            if (!String::IsNullOrEmpty(workerConfigPath) && File::Exists(workerConfigPath))
+            {
+                File::Delete(workerConfigPath);
+            }
+        }
+        catch (Exception ^ex)
+        {
+            Debug::WriteLine("[GstWorker] failed to cleanup config: " + ex->Message);
+        }
+
+        workerConfigPath = nullptr;
+    }
+
+    void GstPlayer::LaunchWorkerWithConfig(String ^configContent)
+    {
+        StopWorker();
+
+        workerConfigPath = Path::Combine(Path::GetTempPath(),
+            String::Format("gstworker_{0}.cfg", Guid::NewGuid().ToString("N")));
+        File::WriteAllText(workerConfigPath, configContent, Encoding::UTF8);
+
+        String ^exePath = Path::Combine(AppDomain::CurrentDomain->BaseDirectory, "GstWorker.exe");
+        if (!File::Exists(exePath))
+        {
+            throw gcnew FileNotFoundException("GstWorker.exe not found", exePath);
+        }
+
+        ProcessStartInfo ^psi = gcnew ProcessStartInfo();
+        psi->FileName = exePath;
+        psi->Arguments = String::Format("--config \"{0}\"", workerConfigPath);
+        psi->UseShellExecute = false;
+        psi->CreateNoWindow = true;
+
+        workerProcess = Process::Start(psi);
+    }
+
     void GstPlayer::Initialize()
     {
         gst_init(nullptr, nullptr);
@@ -273,6 +329,7 @@ namespace GStreamerWrapper
 
     void GstPlayer::Deinitialize()
     {
+        StopWorker();
         StopScreenCaptureRtspServer();
         gst_deinit();
     }
@@ -330,98 +387,66 @@ namespace GStreamerWrapper
     {
         Stop();
 
-        pipeline = gst_pipeline_new("screen-preview");
-        GstElement *src = gst_element_factory_make("d3d11screencapturesrc", "src");
-        GstElement *queue = gst_element_factory_make("queue", "que");
-        GstElement *conv = gst_element_factory_make("d3d11convert", "conv");
-        GstElement *capsfilter = gst_element_factory_make("capsfilter", "caps");
-        GstElement *sink = gst_element_factory_make("d3d11videosink", "sink");
-
-        if (!pipeline || !src || !queue || !conv || !capsfilter || !sink)
+        StringBuilder ^sb = gcnew StringBuilder();
+        sb->AppendLine("mode=preview");
+        sb->AppendLine("[preview]");
+        sb->AppendLine(String::Format("monitor={0}", config.MonitorIndex));
+        if (config.Width > 0 && config.Height > 0)
         {
-            g_printerr("파이프라인 생성 실패\n");
-            if (pipeline)
-            {
-                gst_object_unref(pipeline); pipeline = nullptr;
-            }
-            return;
+            sb->AppendLine(String::Format("width={0}", config.Width));
+            sb->AppendLine(String::Format("height={0}", config.Height));
         }
+        sb->AppendLine(String::Format("framerate={0}", config.Framerate > 0 ? config.Framerate : 30));
+        sb->AppendLine(String::Format("window={0}", (Int64)videoHwnd));
 
-        g_object_set(src,
-            "monitor-index", config.MonitorIndex,
-            "show-cursor", TRUE,
-
-            "capture-api", 1,
-            NULL);
-        g_object_set(sink, "force-aspect-ratio", false, NULL);
-        std::ostringstream caps_str;
-        caps_str << "video/x-raw(memory:D3D11Memory),format=NV12,framerate=30/1";
-        GstCaps *caps = gst_caps_from_string(caps_str.str().c_str());
-        g_object_set(capsfilter, "caps", caps, NULL);
-        gst_caps_unref(caps);
-        //gst_debug_set_default_threshold(GST_LEVEL_INFO);
-        gst_bin_add_many(GST_BIN(pipeline), src, queue, conv, capsfilter, sink, NULL);
-        if (!gst_element_link_many(src, queue, conv, capsfilter, sink, NULL))
-        {
-            gst_debug_set_default_threshold(GST_LEVEL_ERROR);
-            g_printerr("요소 연결 실패\n");
-            gst_object_unref(pipeline);
-            pipeline = nullptr;
-            return;
-        }
-
-        gcHandle = GCHandle::Alloc(this);
-        GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));
-        gst_bus_add_signal_watch(bus);
-        g_signal_connect(bus, "message", G_CALLBACK(BusMessageCallback), GCHandle::ToIntPtr(gcHandle).ToPointer());
-        gst_bus_set_sync_handler(bus, BusSyncHandler, GCHandle::ToIntPtr(gcHandle).ToPointer(), NULL);
-        g_object_unref(bus);
-
-        gst_element_set_state(pipeline, GST_STATE_PLAYING);
+        LaunchWorkerWithConfig(sb->ToString());
     }
 
     void GstPlayer::StartScreenCaptureServer(String ^serverIp, array<StreamConfig> ^configs)
     {
-        //Stop();
+        StopWorker();
 
-        std::string serverIpUtf8 = ToUtf8String(serverIp);
-
-        std::vector<StreamConfigNative> nativeConfigs;
-        for each (StreamConfig cfg in configs)
+        StringBuilder ^sb = gcnew StringBuilder();
+        sb->AppendLine("mode=server");
+        if (!String::IsNullOrEmpty(serverIp))
         {
-            StreamConfigNative ncfg;
-            ncfg.monitor_index = cfg.MonitorIndex;
-            ncfg.crop_x = cfg.CropX;
-            ncfg.crop_y = cfg.CropY;
-            ncfg.crop_w = cfg.CropW;
-            ncfg.crop_h = cfg.CropH;
-            ncfg.width = cfg.Width;
-            ncfg.height = cfg.Height;
-            ncfg.framerate = cfg.Framerate;
-            ncfg.port = cfg.Port;
-            ncfg.bitrate_kbps = cfg.BitrateKbps;
-            ncfg.keyframe_interval = cfg.KeyframeInterval;
-            ncfg.enable_audio = cfg.EnableAudio;
-            ncfg.enable_multicast = cfg.EnableMultiCast;
-            ncfg.streamIndex = cfg.StreamIndex;
-            ncfg.audio_device = ToUtf8String(cfg.AudioDevice);
-            ncfg.enable_hw_accel = cfg.EnableHardwareAccel;
-            ncfg.enable_osd = cfg.EnableOsd;
-            ncfg.profile = ToUtf8String(cfg.Profile);
-            ncfg.bitrate_control = ToUtf8String(cfg.BitrateControl);
-            ncfg.overlay_text = ToUtf8String(cfg.OsdText);
-            ncfg.multicast_ip = ToUtf8String(cfg.MultiCastIP);
-            ncfg.multicast_iface = ToUtf8String(cfg.MultiCastInterface);
-            nativeConfigs.push_back(ncfg);
+            sb->AppendLine(String::Format("server_ip={0}", serverIp));
         }
 
-        RunScreenCaptureRtspServer(serverIpUtf8.empty() ? nullptr : serverIpUtf8.c_str(),
-            nativeConfigs.data(),
-            (int)nativeConfigs.size());
+        int idx = 0;
+        for each (StreamConfig cfg in configs)
+        {
+            sb->AppendLine(String::Format("[stream{0}]", idx++));
+            sb->AppendLine(String::Format("monitor={0}", cfg.MonitorIndex));
+            sb->AppendLine(String::Format("crop_x={0}", cfg.CropX));
+            sb->AppendLine(String::Format("crop_y={0}", cfg.CropY));
+            sb->AppendLine(String::Format("crop_w={0}", cfg.CropW));
+            sb->AppendLine(String::Format("crop_h={0}", cfg.CropH));
+            sb->AppendLine(String::Format("width={0}", cfg.Width));
+            sb->AppendLine(String::Format("height={0}", cfg.Height));
+            sb->AppendLine(String::Format("framerate={0}", cfg.Framerate));
+            sb->AppendLine(String::Format("bitrate={0}", cfg.BitrateKbps));
+            sb->AppendLine(String::Format("keyint={0}", cfg.KeyframeInterval));
+            sb->AppendLine(String::Format("port={0}", cfg.Port));
+            sb->AppendLine(String::Format("stream_index={0}", cfg.StreamIndex));
+            sb->AppendLine(String::Format("enable_audio={0}", cfg.EnableAudio ? "1" : "0"));
+            sb->AppendLine(String::Format("enable_multicast={0}", cfg.EnableMultiCast ? "1" : "0"));
+            if (!String::IsNullOrEmpty(cfg.AudioDevice)) sb->AppendLine(String::Format("audio_device={0}", cfg.AudioDevice));
+            sb->AppendLine(String::Format("enable_hw_accel={0}", cfg.EnableHardwareAccel ? "1" : "0"));
+            sb->AppendLine(String::Format("enable_osd={0}", cfg.EnableOsd ? "1" : "0"));
+            if (!String::IsNullOrEmpty(cfg.BitrateControl)) sb->AppendLine(String::Format("bitrate_control={0}", cfg.BitrateControl));
+            if (!String::IsNullOrEmpty(cfg.Profile)) sb->AppendLine(String::Format("profile={0}", cfg.Profile));
+            if (!String::IsNullOrEmpty(cfg.OsdText)) sb->AppendLine(String::Format("overlay_text={0}", cfg.OsdText));
+            if (!String::IsNullOrEmpty(cfg.MultiCastIP)) sb->AppendLine(String::Format("multicast_ip={0}", cfg.MultiCastIP));
+            if (!String::IsNullOrEmpty(cfg.MultiCastInterface)) sb->AppendLine(String::Format("multicast_iface={0}", cfg.MultiCastInterface));
+        }
+
+        LaunchWorkerWithConfig(sb->ToString());
     }
 
     void GstPlayer::Stop()
     {
+        StopWorker();
         gst_print("GstPlayer::Stop called\n");
         if (pipeline)
         {
@@ -442,6 +467,7 @@ namespace GStreamerWrapper
 
     void GstPlayer::StopPreview()
     {
+        StopWorker();
         if (pipeline)
         {
             gst_element_set_state(pipeline, GST_STATE_NULL);

--- a/GstPlayer/GStreamerWrapper.h
+++ b/GstPlayer/GStreamerWrapper.h
@@ -42,9 +42,13 @@ namespace GStreamerWrapper
     private:
         GstElement *pipeline;
         GCHandle gcHandle;
+        System::Diagnostics::Process ^workerProcess;
+        System::String ^workerConfigPath;
 
         static void BusMessageCallback(GstBus *bus, GstMessage *msg, gpointer data);
         void HandleBusMessage(GstMessage *msg);
+        void StopWorker();
+        void LaunchWorkerWithConfig(System::String ^configContent);
 
     public:
         HWND videoHwnd;

--- a/GstWorker/GstWorker.cpp
+++ b/GstWorker/GstWorker.cpp
@@ -1,20 +1,323 @@
-﻿// GstWorker.cpp : 이 파일에는 'main' 함수가 포함됩니다. 거기서 프로그램 실행이 시작되고 종료됩니다.
-//
-
+#include <windows.h>
+#include <string>
+#include <vector>
+#include <map>
+#include <fstream>
+#include <sstream>
 #include <iostream>
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
 
-int main()
+#include <gst/gst.h>
+#include <gst/video/videooverlay.h>
+
+#include "../GstPlayer/ScreenCaptureServer.h"
+
+#pragma comment(lib, "gstreamer-1.0.lib")
+#pragma comment(lib, "gstvideo-1.0.lib")
+#pragma comment(lib, "gobject-2.0.lib")
+#pragma comment(lib, "glib-2.0.lib")
+#pragma comment(lib, "ole32.lib")
+
+namespace
 {
-    std::cout << "Hello World!\n";
+    struct PreviewConfig
+    {
+        int monitor_index = 0;
+        int width = 0;
+        int height = 0;
+        int framerate = 30;
+        guintptr window_handle = 0;
+    };
+
+    struct WorkerConfig
+    {
+        std::string mode;
+        std::string server_ip;
+        PreviewConfig preview;
+        std::vector<GStreamerWrapper::StreamConfigNative> streams;
+    };
+
+    BOOL WINAPI CtrlHandler(DWORD ctrl)
+    {
+        if (ctrl == CTRL_C_EVENT || ctrl == CTRL_CLOSE_EVENT)
+        {
+            GStreamerWrapper::StopScreenCaptureRtspServer();
+            gst_deinit();
+            return TRUE;
+        }
+        return FALSE;
+    }
+
+    static std::string trim(const std::string &input)
+    {
+        auto begin = std::find_if_not(input.begin(), input.end(), [](char ch)
+                                      { return std::isspace(static_cast<unsigned char>(ch)); });
+        auto end = std::find_if_not(input.rbegin(), input.rend(), [](char ch)
+                                    { return std::isspace(static_cast<unsigned char>(ch)); })
+                       .base();
+        if (begin >= end)
+            return std::string();
+        return std::string(begin, end);
+    }
+
+    static bool read_config_file(const std::wstring &path, WorkerConfig &out)
+    {
+        std::ifstream file(path);
+        if (!file.is_open())
+        {
+            return false;
+        }
+
+        std::map<std::string, std::string> current;
+        std::string section;
+        auto flush_section = [&](const std::string &name)
+        {
+            if (name.empty())
+                return;
+            if (name == "preview")
+            {
+                if (current.count("monitor"))
+                    out.preview.monitor_index = std::stoi(current["monitor"]);
+                if (current.count("width"))
+                    out.preview.width = std::stoi(current["width"]);
+                if (current.count("height"))
+                    out.preview.height = std::stoi(current["height"]);
+                if (current.count("framerate"))
+                    out.preview.framerate = std::stoi(current["framerate"]);
+                if (current.count("window"))
+                    out.preview.window_handle = static_cast<guintptr>(_strtoui64(current["window"].c_str(), nullptr, 10));
+            }
+            else if (name.rfind("stream", 0) == 0)
+            {
+                GStreamerWrapper::StreamConfigNative cfg{};
+                if (current.count("monitor"))
+                    cfg.monitor_index = std::stoi(current["monitor"]);
+                if (current.count("crop_x"))
+                    cfg.crop_x = std::stoi(current["crop_x"]);
+                if (current.count("crop_y"))
+                    cfg.crop_y = std::stoi(current["crop_y"]);
+                if (current.count("crop_w"))
+                    cfg.crop_w = std::stoi(current["crop_w"]);
+                if (current.count("crop_h"))
+                    cfg.crop_h = std::stoi(current["crop_h"]);
+                if (current.count("width"))
+                    cfg.width = std::stoi(current["width"]);
+                if (current.count("height"))
+                    cfg.height = std::stoi(current["height"]);
+                if (current.count("framerate"))
+                    cfg.framerate = std::stoi(current["framerate"]);
+                if (current.count("bitrate"))
+                    cfg.bitrate_kbps = std::stoi(current["bitrate"]);
+                if (current.count("keyint"))
+                    cfg.keyframe_interval = std::stoi(current["keyint"]);
+                if (current.count("port"))
+                    cfg.port = std::stoi(current["port"]);
+                if (current.count("stream_index"))
+                    cfg.streamIndex = std::stoi(current["stream_index"]);
+                if (current.count("enable_audio"))
+                    cfg.enable_audio = (current["enable_audio"] == "1" || current["enable_audio"] == "true");
+                if (current.count("enable_multicast"))
+                    cfg.enable_multicast = (current["enable_multicast"] == "1" || current["enable_multicast"] == "true");
+                if (current.count("audio_device"))
+                    cfg.audio_device = current["audio_device"];
+                if (current.count("enable_hw_accel"))
+                    cfg.enable_hw_accel = (current["enable_hw_accel"] == "1" || current["enable_hw_accel"] == "true");
+                if (current.count("enable_osd"))
+                    cfg.enable_osd = (current["enable_osd"] == "1" || current["enable_osd"] == "true");
+                if (current.count("bitrate_control"))
+                    cfg.bitrate_control = current["bitrate_control"];
+                if (current.count("profile"))
+                    cfg.profile = current["profile"];
+                if (current.count("overlay_text"))
+                    cfg.overlay_text = current["overlay_text"];
+                if (current.count("multicast_ip"))
+                    cfg.multicast_ip = current["multicast_ip"];
+                if (current.count("multicast_iface"))
+                    cfg.multicast_iface = current["multicast_iface"];
+                out.streams.push_back(cfg);
+            }
+            current.clear();
+        };
+
+        std::string line;
+        while (std::getline(file, line))
+        {
+            line = trim(line);
+            if (line.empty() || line[0] == '#')
+                continue;
+
+            if (line.front() == '[' && line.back() == ']')
+            {
+                flush_section(section);
+                section = line.substr(1, line.size() - 2);
+                continue;
+            }
+
+            auto pos = line.find('=');
+            if (pos == std::string::npos)
+                continue;
+            std::string key = trim(line.substr(0, pos));
+            std::string value = trim(line.substr(pos + 1));
+            if (section.empty())
+            {
+                if (key == "mode")
+                    out.mode = value;
+                else if (key == "server_ip")
+                    out.server_ip = value;
+            }
+            else
+            {
+                current[key] = value;
+            }
+        }
+        flush_section(section);
+
+        return !out.mode.empty();
+    }
+
+    static gboolean preview_bus_cb(GstBus *, GstMessage *msg, gpointer user_data)
+    {
+        GMainLoop *loop = static_cast<GMainLoop *>(user_data);
+        switch (GST_MESSAGE_TYPE(msg))
+        {
+        case GST_MESSAGE_ERROR:
+        case GST_MESSAGE_EOS:
+            g_main_loop_quit(loop);
+            break;
+        default:
+            break;
+        }
+        return TRUE;
+    }
+
+    static GstBusSyncReply preview_sync_handler(GstBus * /*bus*/, GstMessage *msg, gpointer data)
+    {
+        if (gst_is_video_overlay_prepare_window_handle_message(msg))
+        {
+            GstVideoOverlay *overlay = GST_VIDEO_OVERLAY(GST_MESSAGE_SRC(msg));
+            gst_video_overlay_set_window_handle(overlay, (guintptr)data);
+            return GST_BUS_DROP;
+        }
+        return GST_BUS_PASS;
+    }
+
+    static int run_preview(const PreviewConfig &cfg)
+    {
+        gst_init(nullptr, nullptr);
+
+        GstElement *pipeline = gst_pipeline_new("screen-preview");
+        GstElement *src = gst_element_factory_make("d3d11screencapturesrc", "src");
+        GstElement *queue = gst_element_factory_make("queue", "que");
+        GstElement *conv = gst_element_factory_make("d3d11convert", "conv");
+        GstElement *capsfilter = gst_element_factory_make("capsfilter", "caps");
+        GstElement *sink = gst_element_factory_make("d3d11videosink", "sink");
+
+        if (!pipeline || !src || !queue || !conv || !capsfilter || !sink)
+        {
+            g_printerr("파이프라인 생성 실패\n");
+            if (pipeline)
+                gst_object_unref(pipeline);
+            return -1;
+        }
+
+        g_object_set(src, "monitor-index", cfg.monitor_index, "show-cursor", TRUE, "capture-api", 1, NULL);
+        g_object_set(sink, "force-aspect-ratio", FALSE, NULL);
+
+        std::ostringstream caps_str;
+        caps_str << "video/x-raw(memory:D3D11Memory),format=NV12,framerate=" << cfg.framerate << "/1";
+        if (cfg.width > 0 && cfg.height > 0)
+        {
+            caps_str << ",width=" << cfg.width << ",height=" << cfg.height;
+        }
+        GstCaps *caps = gst_caps_from_string(caps_str.str().c_str());
+        g_object_set(capsfilter, "caps", caps, NULL);
+        gst_caps_unref(caps);
+
+        gst_bin_add_many(GST_BIN(pipeline), src, queue, conv, capsfilter, sink, NULL);
+        if (!gst_element_link_many(src, queue, conv, capsfilter, sink, NULL))
+        {
+            g_printerr("요소 연결 실패\n");
+            gst_object_unref(pipeline);
+            return -2;
+        }
+
+        GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+        GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));
+        gst_bus_add_signal_watch(bus);
+        g_signal_connect(bus, "message", G_CALLBACK(preview_bus_cb), loop);
+        gst_bus_set_sync_handler(bus, preview_sync_handler, (gpointer)cfg.window_handle, NULL);
+        g_object_unref(bus);
+
+        gst_element_set_state(pipeline, GST_STATE_PLAYING);
+        g_main_loop_run(loop);
+
+        gst_element_set_state(pipeline, GST_STATE_NULL);
+        gst_object_unref(pipeline);
+        g_main_loop_unref(loop);
+
+        gst_deinit();
+        return 0;
+    }
+
+    static int run_server(const WorkerConfig &cfg)
+    {
+        gst_init(nullptr, nullptr);
+        SetConsoleCtrlHandler(CtrlHandler, TRUE);
+        GStreamerWrapper::RunScreenCaptureRtspServer(cfg.server_ip.empty() ? nullptr : cfg.server_ip.c_str(),
+                                                     cfg.streams.data(),
+                                                     static_cast<int>(cfg.streams.size()));
+        // Keep process alive until external termination (Stop) or Ctrl+C
+        while (true)
+        {
+            Sleep(200);
+        }
+        return 0;
+    }
 }
 
-// 프로그램 실행: <Ctrl+F5> 또는 [디버그] > [디버깅하지 않고 시작] 메뉴
-// 프로그램 디버그: <F5> 키 또는 [디버그] > [디버깅 시작] 메뉴
+int wmain(int argc, wchar_t **argv)
+{
+    if (argc < 2)
+    {
+        std::wcerr << L"Usage: GstWorker --config <path>\n";
+        return 1;
+    }
 
-// 시작을 위한 팁: 
-//   1. [솔루션 탐색기] 창을 사용하여 파일을 추가/관리합니다.
-//   2. [팀 탐색기] 창을 사용하여 소스 제어에 연결합니다.
-//   3. [출력] 창을 사용하여 빌드 출력 및 기타 메시지를 확인합니다.
-//   4. [오류 목록] 창을 사용하여 오류를 봅니다.
-//   5. [프로젝트] > [새 항목 추가]로 이동하여 새 코드 파일을 만들거나, [프로젝트] > [기존 항목 추가]로 이동하여 기존 코드 파일을 프로젝트에 추가합니다.
-//   6. 나중에 이 프로젝트를 다시 열려면 [파일] > [열기] > [프로젝트]로 이동하고 .sln 파일을 선택합니다.
+    std::wstring config_path;
+    for (int i = 1; i < argc; ++i)
+    {
+        std::wstring arg = argv[i];
+        if (arg == L"--config" && i + 1 < argc)
+        {
+            config_path = argv[++i];
+        }
+    }
+
+    if (config_path.empty())
+    {
+        std::wcerr << L"Missing --config argument\n";
+        return 1;
+    }
+
+    WorkerConfig config;
+    if (!read_config_file(config_path, config))
+    {
+        std::wcerr << L"Failed to parse config file: " << config_path << L"\n";
+        return 1;
+    }
+
+    if (config.mode == "preview")
+    {
+        return run_preview(config.preview);
+    }
+    if (config.mode == "server")
+    {
+        return run_server(config);
+    }
+
+    std::wcerr << L"Unknown mode: " << std::wstring(config.mode.begin(), config.mode.end()) << L"\n";
+    return 1;
+}
+

--- a/GstWorker/GstWorker.vcxproj
+++ b/GstWorker/GstWorker.vcxproj
@@ -124,6 +124,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="GstWorker.cpp" />
+    <ClCompile Include="..\GstPlayer\ScreenCaptureServer.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
## Summary
- add a standalone GstWorker executable that hosts preview and RTSP pipelines from config files
- update the GStreamer wrapper to launch the worker subprocess so pipeline crashes stay isolated from the .NET host
- keep existing managed API shapes while generating and cleaning temporary configs for worker startup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b229d57e4832f87177e041d32a6b9)