### PR TITLE
Remove CLR usage and send preview configs

### DIFF
--- a/GStreamerDotNetTest/GstProcessManager.cs
+++ b/GStreamerDotNetTest/GstProcessManager.cs
@@ -42,6 +42,7 @@ namespace GStreamerDotNetTest
         private string _lastServerIp = string.Empty;
         private IntPtr _lastPreviewHandle = IntPtr.Zero;
         private int _lastPreviewMonitor = 0;
+        private StreamConfig _lastPreviewConfig = null;
         private bool _disposed;
 
         public event Action<string> OutputReceived;
@@ -88,7 +89,7 @@ namespace GStreamerDotNetTest
                 }
                 if (_lastPreviewHandle != IntPtr.Zero)
                 {
-                    SendStartPreview(_lastPreviewHandle, _lastPreviewMonitor);
+                    SendStartPreview(_lastPreviewHandle, _lastPreviewMonitor, _lastPreviewConfig);
                 }
             }
         }
@@ -130,29 +131,8 @@ namespace GStreamerDotNetTest
 
             foreach (var c in _lastConfigs)
             {
-                cmd.AppendFormat(" {0} {1} {2} {3} {4} {5} {6} {7} {8} {9} {10} {11} {12} {13} {14} {15} {16} {17} {18} {19} {20} {21}",
-                    c.MonitorIndex,
-                    c.CropX,
-                    c.CropY,
-                    c.CropW,
-                    c.CropH,
-                    c.Width,
-                    c.Height,
-                    c.Framerate,
-                    c.BitrateKbps,
-                    c.KeyframeInterval,
-                    c.Port,
-                    c.StreamIndex,
-                    c.EnableAudio ? 1 : 0,
-                    c.EnableMultiCast ? 1 : 0,
-                    Encode(c.AudioDevice),
-                    c.EnableHardwareAccel ? 1 : 0,
-                    c.EnableOsd ? 1 : 0,
-                    Encode(c.BitrateControl),
-                    Encode(c.Profile),
-                    Encode(c.OsdText),
-                    Encode(c.MultiCastIP),
-                    Encode(c.MultiCastInterface));
+                cmd.Append(' ');
+                AppendConfig(cmd, c);
             }
 
             SendCommand(cmd.ToString());
@@ -163,11 +143,22 @@ namespace GStreamerDotNetTest
             SendCommand("CMD_STOP_SERVER");
         }
 
-        public void SendStartPreview(IntPtr hwnd, int monitorIndex)
+        public void SendStartPreview(IntPtr hwnd, int monitorIndex, StreamConfig previewConfig = null)
         {
             _lastPreviewHandle = hwnd;
             _lastPreviewMonitor = monitorIndex;
-            SendCommand($"CMD_START_PREVIEW {hwnd.ToInt64()} {monitorIndex}");
+            _lastPreviewConfig = previewConfig;
+
+            var cmd = new StringBuilder();
+            cmd.AppendFormat("CMD_START_PREVIEW {0} {1}", hwnd.ToInt64(), monitorIndex);
+
+            if (previewConfig != null)
+            {
+                cmd.Append(" CFG ");
+                AppendConfig(cmd, previewConfig);
+            }
+
+            SendCommand(cmd.ToString());
         }
 
         public void SendStopPreview()
@@ -200,6 +191,33 @@ namespace GStreamerDotNetTest
             // [수정] 빈 값일 경우 Base64 변환 시 ""가 되므로, 공백 파싱이 밀리는 문제 해결을 위해 명시적 토큰 사용
             if (string.IsNullOrEmpty(value)) return "__EMPTY__";
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+        }
+
+        private static void AppendConfig(StringBuilder cmd, StreamConfig c)
+        {
+            cmd.AppendFormat("{0} {1} {2} {3} {4} {5} {6} {7} {8} {9} {10} {11} {12} {13} {14} {15} {16} {17} {18} {19} {20} {21}",
+                c.MonitorIndex,
+                c.CropX,
+                c.CropY,
+                c.CropW,
+                c.CropH,
+                c.Width,
+                c.Height,
+                c.Framerate,
+                c.BitrateKbps,
+                c.KeyframeInterval,
+                c.Port,
+                c.StreamIndex,
+                c.EnableAudio ? 1 : 0,
+                c.EnableMultiCast ? 1 : 0,
+                Encode(c.AudioDevice),
+                c.EnableHardwareAccel ? 1 : 0,
+                c.EnableOsd ? 1 : 0,
+                Encode(c.BitrateControl),
+                Encode(c.Profile),
+                Encode(c.OsdText),
+                Encode(c.MultiCastIP),
+                Encode(c.MultiCastInterface));
         }
 
         public void Dispose()

--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -362,7 +362,7 @@ namespace GStreamerDotNetTest
                     BitrateControl = "CBR",
                     Profile = "high",
                 };
-                _gstProcessManager?.SendStartPreview(_videoHost.Handle, monitorIndex);
+                _gstProcessManager?.SendStartPreview(_videoHost.Handle, monitorIndex, cfg);
             }
         }
 

--- a/GstPlayer/GstPlayer.vcxproj
+++ b/GstPlayer/GstPlayer.vcxproj
@@ -54,8 +54,7 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{23A886BB-2116-481A-B264-FD878C21FCA0}</ProjectGuid>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <Keyword>ManagedCProj</Keyword>
+    <Keyword>Win32Proj</Keyword>
     <RootNamespace>GstPlayer</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>GstStreamerWrapper</ProjectName>
@@ -65,70 +64,70 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+    <CLRSupport>false</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='re201|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+    <CLRSupport>false</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='remote|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+    <CLRSupport>false</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='re16|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+    <CLRSupport>false</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+    <CLRSupport>false</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+    <CLRSupport>false</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='re201|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+    <CLRSupport>false</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='remote|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+      <CLRSupport>false</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='re16|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+      <CLRSupport>false</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+      <CLRSupport>false</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -200,7 +199,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);_SERVPROV_H_</PreprocessorDefinitions>
       <LanguageStandard>Default</LanguageStandard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <CompileAsManaged>true</CompileAsManaged>
+      <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);gstreamer-1.0.lib;gstbase-1.0.lib;gstvideo-1.0.lib;gobject-2.0.lib;glib-2.0.lib;Shcore.lib;gstpbutils-1.0.lib;gstapp-1.0.lib;gstrtspserver-1.0.lib;gstrtsp-1.0.lib</AdditionalDependencies>

--- a/GstPlayer/main.cpp
+++ b/GstPlayer/main.cpp
@@ -36,45 +36,53 @@ namespace
         return result;
     }
 
+    bool ParseStreamConfig(std::istream& iss, StreamConfigNative& cfg)
+    {
+        std::string audio_b64, bitrate_b64, profile_b64, osd_b64, mc_ip_b64, mc_iface_b64;
+
+        // [수정] bool 타입은 직접 읽지 말고 int로 읽어서 변환 (스트림 파싱 안정성)
+        int i_audio = 0, i_multicast = 0, i_hw = 0, i_osd = 0;
+
+        if (!(iss >> cfg.monitor_index >> cfg.crop_x >> cfg.crop_y >> cfg.crop_w >> cfg.crop_h
+            >> cfg.width >> cfg.height >> cfg.framerate >> cfg.bitrate_kbps >> cfg.keyframe_interval
+            >> cfg.port >> cfg.streamIndex
+            >> i_audio          // bool -> int
+            >> i_multicast      // bool -> int
+            >> audio_b64
+            >> i_hw             // bool -> int
+            >> i_osd            // bool -> int
+            >> bitrate_b64 >> profile_b64
+            >> osd_b64 >> mc_ip_b64 >> mc_iface_b64))
+        {
+            return false;
+        }
+
+        // int -> bool 변환
+        cfg.enable_audio = (i_audio != 0);
+        cfg.enable_multicast = (i_multicast != 0);
+        cfg.enable_hw_accel = (i_hw != 0);
+        cfg.enable_osd = (i_osd != 0);
+
+        cfg.audio_device = DecodeBase64(audio_b64);
+        cfg.bitrate_control = DecodeBase64(bitrate_b64);
+        cfg.profile = DecodeBase64(profile_b64);
+        cfg.overlay_text = DecodeBase64(osd_b64);
+        cfg.multicast_ip = DecodeBase64(mc_ip_b64);
+        cfg.multicast_iface = DecodeBase64(mc_iface_b64);
+
+        return true;
+    }
+
     bool ParseStreamConfigs(std::istream& iss, int count, std::vector<StreamConfigNative>& out)
     {
         out.clear();
         for (int i = 0; i < count; ++i)
         {
             StreamConfigNative cfg{};
-            std::string audio_b64, bitrate_b64, profile_b64, osd_b64, mc_ip_b64, mc_iface_b64;
-
-            // [수정] bool 타입은 직접 읽지 말고 int로 읽어서 변환 (스트림 파싱 안정성)
-            int i_audio = 0, i_multicast = 0, i_hw = 0, i_osd = 0;
-
-            if (!(iss >> cfg.monitor_index >> cfg.crop_x >> cfg.crop_y >> cfg.crop_w >> cfg.crop_h
-                >> cfg.width >> cfg.height >> cfg.framerate >> cfg.bitrate_kbps >> cfg.keyframe_interval
-                >> cfg.port >> cfg.streamIndex
-                >> i_audio          // bool -> int
-                >> i_multicast      // bool -> int
-                >> audio_b64
-                >> i_hw             // bool -> int
-                >> i_osd            // bool -> int
-                >> bitrate_b64 >> profile_b64
-                >> osd_b64 >> mc_ip_b64 >> mc_iface_b64))
+            if (!ParseStreamConfig(iss, cfg))
             {
-                // 디버깅을 위해 어디서 실패했는지 출력하고 싶다면:
-                // std::cout << "Parse failed at index " << i << std::endl;
                 return false;
             }
-
-            // int -> bool 변환
-            cfg.enable_audio = (i_audio != 0);
-            cfg.enable_multicast = (i_multicast != 0);
-            cfg.enable_hw_accel = (i_hw != 0);
-            cfg.enable_osd = (i_osd != 0);
-
-            cfg.audio_device = DecodeBase64(audio_b64);
-            cfg.bitrate_control = DecodeBase64(bitrate_b64);
-            cfg.profile = DecodeBase64(profile_b64);
-            cfg.overlay_text = DecodeBase64(osd_b64);
-            cfg.multicast_ip = DecodeBase64(mc_ip_b64);
-            cfg.multicast_iface = DecodeBase64(mc_iface_b64);
 
             out.push_back(cfg);
         }
@@ -168,6 +176,18 @@ int main()
             long long hwnd_val = 0;
             int monitorIdx = 0;
             if (iss >> hwnd_val >> monitorIdx) {
+                // 선택적으로 미리보기 설정을 함께 전달받을 수 있음 (CFG 토큰 이후)
+                std::string token;
+                if (iss >> token && token == "CFG")
+                {
+                    StreamConfigNative cfg{};
+                    if (ParseStreamConfig(iss, cfg))
+                    {
+                        g_last_configs.clear();
+                        g_last_configs.push_back(cfg);
+                    }
+                }
+
                 StartPreviewWithMonitor(reinterpret_cast<HWND>(static_cast<intptr_t>(hwnd_val)), monitorIdx);
                 std::cout << "PREVIEW_STARTED" << std::endl;
             }


### PR DESCRIPTION
## Summary
- remove CLR build settings so the native wrapper builds without /clr
- allow the native preview command to accept full stream configuration data
- propagate preview settings from the .NET UI and preserve them across restarts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b67e97104832fb5a5bccd90e67339)