### PR TITLE
Handle preview overlay resize updates

### DIFF
--- a/GStreamerDotNetTest/GstProcessManager.cs
+++ b/GStreamerDotNetTest/GstProcessManager.cs
@@ -167,6 +167,15 @@ namespace GStreamerDotNetTest
             SendCommand("CMD_STOP_PREVIEW");
         }
 
+        public void SendUpdatePreviewRectangle(IntPtr hwnd)
+        {
+            _lastPreviewHandle = hwnd;
+            if (hwnd == IntPtr.Zero)
+                return;
+
+            SendCommand($"CMD_UPDATE_PREVIEW_RECT {hwnd.ToInt64()}");
+        }
+
         private void SendCommand(string command)
         {
             lock (_sync)

--- a/GStreamerDotNetTest/GstVideoHost.cs
+++ b/GStreamerDotNetTest/GstVideoHost.cs
@@ -48,6 +48,9 @@ namespace GStreamerDotNetTest
         /// <summary>자식 HWND가 파괴된 직후 알림</summary>
         public event EventHandler HwndDestroyed;
 
+        /// <summary>자식 HWND의 크기가 바뀌었을 때 알림 (미리보기 렌더링 영역 보정용)</summary>
+        public event EventHandler HwndResized;
+
         // ===== HwndHost overrides =====
         protected override HandleRef BuildWindowCore(HandleRef hwndParent)
         {
@@ -104,6 +107,7 @@ namespace GStreamerDotNetTest
                 int w = Math.Max(1, (int)Math.Round(rcBoundingBox.Width));
                 int h = Math.Max(1, (int)Math.Round(rcBoundingBox.Height));
                 SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, w, h, SWP_NOZORDER | SWP_NOACTIVATE);
+                HwndResized?.Invoke(this, EventArgs.Empty);
             }
         }
 
@@ -119,6 +123,7 @@ namespace GStreamerDotNetTest
                 int w = Math.Max(1, (int)Math.Round(sizeInfo.NewSize.Width));
                 int h = Math.Max(1, (int)Math.Round(sizeInfo.NewSize.Height));
                 SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, w, h, SWP_NOZORDER | SWP_NOACTIVATE);
+                HwndResized?.Invoke(this, EventArgs.Empty);
             }
         }
     }

--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -89,6 +89,7 @@ namespace GStreamerDotNetTest
         private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
             _videoHost = new GstVideoHost();
+            _videoHost.HwndResized += (s, _) => _gstProcessManager?.SendUpdatePreviewRectangle(_videoHost.Handle);
             videoContainer.Child = _videoHost;
 
             string exePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "GstServer.exe");
@@ -342,6 +343,12 @@ namespace GStreamerDotNetTest
             }
 
             int width, height;
+            if (_videoHost.Handle == IntPtr.Zero)
+            {
+                Debug.WriteLine("Preview host handle not created yet. Ignoring preview request.");
+                return;
+            }
+
             if (DisplayHelper.TryGetMonitorSize(monitorIndex, out width, out height))
             {
                 var cfg = new StreamConfig

--- a/GstPlayer/GStreamerWrapper.cpp
+++ b/GstPlayer/GStreamerWrapper.cpp
@@ -155,5 +155,25 @@ namespace GStreamerWrapper
     {
         StopPreviewInternal();
     }
+
+    bool RefreshPreviewOverlay(HWND window)
+    {
+        if (!window)
+            window = g_preview_window;
+
+        if (!g_preview_pipeline || !window)
+            return false;
+
+        g_preview_window = window;
+
+        GstElement* sink = gst_bin_get_by_name(GST_BIN(g_preview_pipeline), "sink");
+        if (!sink)
+            return false;
+
+        ApplyOverlayHandle(sink, window);
+        UpdateOverlayGeometry(sink, window);
+        gst_object_unref(sink);
+        return true;
+    }
 }
 

--- a/GstPlayer/GStreamerWrapper.h
+++ b/GstPlayer/GStreamerWrapper.h
@@ -38,6 +38,9 @@ namespace GStreamerWrapper
     bool StartPreview(const StreamConfigNative& config, HWND window);
     void StopPreview();
 
+    // 현재 미리보기 윈도우에 대해 render rectangle을 다시 적용
+    bool RefreshPreviewOverlay(HWND window);
+
     void RunScreenCaptureRtspServer(const char* serverIp,
         const StreamConfigNative* configs,
         int count);

--- a/GstPlayer/main.cpp
+++ b/GstPlayer/main.cpp
@@ -197,6 +197,15 @@ int main()
             StopPreview();
             std::cout << "PREVIEW_STOPPED" << std::endl;
         }
+        else if (cmd == "CMD_UPDATE_PREVIEW_RECT")
+        {
+            long long hwnd_val = 0;
+            if (iss >> hwnd_val)
+            {
+                bool updated = RefreshPreviewOverlay(reinterpret_cast<HWND>(static_cast<intptr_t>(hwnd_val)));
+                std::cout << (updated ? "PREVIEW_RECT_UPDATED" : "PREVIEW_RECT_SKIPPED") << std::endl;
+            }
+        }
         else if (cmd == "CMD_EXIT")
         {
             break;


### PR DESCRIPTION
## Summary
- add resize notifications from the WPF HwndHost to keep the preview render rectangle in sync
- add a managed command and native handler to refresh the preview overlay geometry when the host size changes
- guard preview commands when the host window handle has not been created yet

## Testing
- not run (not supported in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b731b3ef0832fb3f808e58c6b314a)