### PR TITLE
Enable shared copy pipeline at 5+ streams and collapse stream tabs; derive pipeline from first stream config

### DIFF
--- a/GStreamerDotNetTest/MainWindow.xaml.cs
+++ b/GStreamerDotNetTest/MainWindow.xaml.cs
@@ -12,6 +12,7 @@ namespace GStreamerDotNetTest
     public partial class MainWindow : Window
     {
         const int defaultResIndex = 3; // 0: Input, 1: 1080p, 2: 720p, 3: 540p
+        const int streamTabCollapseThreshold = 5;
         private GstProcessManager _gstProcessManager;
         private GstVideoHost _videoHost;
         private StreamConfig[] _configs = new StreamConfig[0];
@@ -221,106 +222,113 @@ namespace GStreamerDotNetTest
 
         // --- 이하 나머지 코드는 변경 없습니다. ---
 
-        private StreamConfig[] CollectStreamConfigs()
+        private StreamConfig BuildConfigFromSetting(StreamSetting s)
         {
-            var list = new List<StreamConfig>();
-            int idx = 0;
+            var cfg = new StreamConfig();
 
-            foreach (var s in _streamSettings)
+            int mi;
+            int.TryParse(s.Monitor.Text, out mi);
+            cfg.MonitorIndex = mi;
+
+            int cx, cy, cw, ch;
+            int.TryParse(s.CropX.Text, out cx);
+            int.TryParse(s.CropY.Text, out cy);
+            int.TryParse(s.CropW.Text, out cw);
+            int.TryParse(s.CropH.Text, out ch);
+            cfg.CropX = cx; cfg.CropY = cy; cfg.CropW = cw; cfg.CropH = ch;
+
+            bool useInput = s.UseInputResolution;
+
+            if (useInput)
             {
-                var cfg = new StreamConfig();
-
-                int mi;
-                int.TryParse(s.Monitor.Text, out mi);
-                cfg.MonitorIndex = mi;
-
-                int cx, cy, cw, ch;
-                int.TryParse(s.CropX.Text, out cx);
-                int.TryParse(s.CropY.Text, out cy);
-                int.TryParse(s.CropW.Text, out cw);
-                int.TryParse(s.CropH.Text, out ch);
-                cfg.CropX = cx; cfg.CropY = cy; cfg.CropW = cw; cfg.CropH = ch;
-
-                bool useInput = s.UseInputResolution;
-
-                if (useInput)
+                if (cw > 0 && ch > 0)
                 {
-                    if (cw > 0 && ch > 0)
-                    {
-                        cfg.Width = cw;
-                        cfg.Height = ch;
-                    }
-                    else
-                    {
-                        int mw, mh;
-                        if (DisplayHelper.TryGetMonitorSize(cfg.MonitorIndex, out mw, out mh))
-                        {
-                            cfg.CropX = 0; cfg.CropY = 0;
-                            cfg.CropW = mw; cfg.CropH = mh;
-                            cfg.Width = mw; cfg.Height = mh;
-                        }
-                        else
-                        {
-                            cfg.Width = 0; cfg.Height = 0;
-                        }
-                    }
+                    cfg.Width = cw;
+                    cfg.Height = ch;
                 }
                 else
                 {
-                    string res = s.Resolution.SelectedItem as string;
-                    if (res == "1080p") { cfg.Width = 1920; cfg.Height = 1080; }
-                    else if (res == "720p") { cfg.Width = 1280; cfg.Height = 720; }
-                    else if (res == "540p") { cfg.Width = 960; cfg.Height = 540; }
-                    else { cfg.Width = 0; cfg.Height = 0; }
-                }
-
-                int fr, br, ki;
-                int.TryParse(s.FrameRate.Text, out fr);
-                int.TryParse(s.Bitrate.Text, out br);
-                int.TryParse(s.Keyframe.Text, out ki);
-                cfg.Framerate = fr;
-                cfg.BitrateKbps = br;
-                cfg.KeyframeInterval = ki;
-                cfg.Port = 10554 + idx++;
-                cfg.StreamIndex = idx;
-                cfg.BitrateControl = s.BitrateControl.SelectedItem as string;
-                cfg.Profile = s.Profile.SelectedItem as string;
-
-                cfg.EnableAudio = s.AudioEnable.SelectedIndex == 0;
-                cfg.AudioDevice = s.AudioDevice.SelectedItem as string;
-
-                cfg.EnableHardwareAccel = s.HwAccel.SelectedIndex == 0;
-                cfg.EnableOsd = s.OsdEnable.SelectedIndex == 0;
-                cfg.EnableMultiCast = (s.MultiCastEnable != null && s.MultiCastEnable.SelectedIndex == 1);
-
-                if (s.MultiCastIp != null)
-                {
-                    cfg.MultiCastIP = s.MultiCastIp.Text.Trim();
-                    if (string.IsNullOrWhiteSpace(cfg.MultiCastIP)) cfg.MultiCastIP = null;
-                }
-
-                //if (s.MultiCastInterface != null)
-                //{
-                //    var selectedInterface = s.MultiCastInterface.SelectedItem as string;
-                //    if (string.IsNullOrWhiteSpace(selectedInterface)) selectedInterface = null;
-                //    cfg.MultiCastInterface = selectedInterface;
-                //}01
-                if (s.MultiCastInterface != null)
-                {
-                    var selectedInterfaceName = s.MultiCastInterface.SelectedItem as string; // "이더넷 2"
-                    string ipAddress = GetIpAddressFromInterfaceName(selectedInterfaceName);  // "192.168.10.15"
-
-                    if (string.IsNullOrWhiteSpace(ipAddress))
+                    int mw, mh;
+                    if (DisplayHelper.TryGetMonitorSize(cfg.MonitorIndex, out mw, out mh))
                     {
-                        cfg.MultiCastInterface = null;
-                        Debug.WriteLine($"경고: 인터페이스 '{selectedInterfaceName}'에서 IPv4 주소를 찾지 못했습니다.");
+                        cfg.CropX = 0; cfg.CropY = 0;
+                        cfg.CropW = mw; cfg.CropH = mh;
+                        cfg.Width = mw; cfg.Height = mh;
                     }
                     else
                     {
-                        // C++ 래퍼로 IP 주소를 전달합니다.
-                        cfg.MultiCastInterface = ipAddress;
+                        cfg.Width = 0; cfg.Height = 0;
                     }
                 }
+            }
+            else
+            {
+                string res = s.Resolution.SelectedItem as string;
+                if (res == "1080p") { cfg.Width = 1920; cfg.Height = 1080; }
+                else if (res == "720p") { cfg.Width = 1280; cfg.Height = 720; }
+                else if (res == "540p") { cfg.Width = 960; cfg.Height = 540; }
+                else { cfg.Width = 0; cfg.Height = 0; }
+            }
+
+            int fr, br, ki;
+            int.TryParse(s.FrameRate.Text, out fr);
+            int.TryParse(s.Bitrate.Text, out br);
+            int.TryParse(s.Keyframe.Text, out ki);
+            cfg.Framerate = fr;
+            cfg.BitrateKbps = br;
+            cfg.KeyframeInterval = ki;
+            cfg.BitrateControl = s.BitrateControl.SelectedItem as string;
+            cfg.Profile = s.Profile.SelectedItem as string;
+
+            cfg.EnableAudio = s.AudioEnable.SelectedIndex == 0;
+            cfg.AudioDevice = s.AudioDevice.SelectedItem as string;
+
+            cfg.EnableHardwareAccel = s.HwAccel.SelectedIndex == 0;
+            cfg.EnableOsd = s.OsdEnable.SelectedIndex == 0;
+            cfg.EnableMultiCast = (s.MultiCastEnable != null && s.MultiCastEnable.SelectedIndex == 1);
+
+            if (s.MultiCastIp != null)
+            {
+                cfg.MultiCastIP = s.MultiCastIp.Text.Trim();
+                if (string.IsNullOrWhiteSpace(cfg.MultiCastIP)) cfg.MultiCastIP = null;
+            }
+
+            if (s.MultiCastInterface != null)
+            {
+                var selectedInterfaceName = s.MultiCastInterface.SelectedItem as string; // "이더넷 2"
+                string ipAddress = GetIpAddressFromInterfaceName(selectedInterfaceName);  // "192.168.10.15"
+
+                if (string.IsNullOrWhiteSpace(ipAddress))
+                {
+                    cfg.MultiCastInterface = null;
+                    Debug.WriteLine($"경고: 인터페이스 '{selectedInterfaceName}'에서 IPv4 주소를 찾지 못했습니다.");
+                }
+                else
+                {
+                    // C++ 래퍼로 IP 주소를 전달합니다.
+                    cfg.MultiCastInterface = ipAddress;
+                }
+            }
+
+            return cfg;
+        }
+
+        private StreamConfig[] CollectStreamConfigs()
+        {
+            var list = new List<StreamConfig>();
+            int requestedCount;
+            if (!int.TryParse(Textbox_numofstreamer.Text, out requestedCount) || requestedCount < 0)
+                requestedCount = _streamSettings.Count;
+
+            bool useSingleTabSetting = requestedCount >= streamTabCollapseThreshold && _streamSettings.Count > 0;
+            int loopCount = useSingleTabSetting ? requestedCount : _streamSettings.Count;
+
+            for (int i = 0; i < loopCount; i++)
+            {
+                StreamSetting source = useSingleTabSetting ? _streamSettings[0] : _streamSettings[i];
+                var cfg = BuildConfigFromSetting(source);
+                cfg.Port = 10554 + i;
+                cfg.StreamIndex = i + 1;
                 list.Add(cfg);
             }
 
@@ -394,7 +402,9 @@ namespace GStreamerDotNetTest
         {
             StreamSettingsTab.Items.Clear();
             _streamSettings.Clear();
-            for (int i = 0; i < count; i++)
+            int tabCount = count >= streamTabCollapseThreshold ? 1 : count;
+
+            for (int i = 0; i < tabCount; i++)
             {
                 var setting = CreateStreamSettingTab(i);
                 _streamSettings.Add(setting);

--- a/GstPlayer/ScreenCaptureServer.cpp
+++ b/GstPlayer/ScreenCaptureServer.cpp
@@ -26,6 +26,9 @@
 #include <windows.h>
 
 namespace GStreamerWrapper {
+    namespace {
+        constexpr size_t kSharedMasterPipelineThreshold = 5;
+    }
 
     static std::string g_server_ip;
     static std::vector<StreamConfigNative> g_configs;
@@ -1587,53 +1590,44 @@ namespace GStreamerWrapper {
         // =========================================================
                 // [수정] 16개 초과 시 Shared Master Pipeline 구축 및 시작
                 // =========================================================
-        if (g_configs.size() > 16) {
+        if (g_configs.size() >= kSharedMasterPipelineThreshold) {
             g_print(">>> [스트림 개수 %zu개] Shared Master Pipeline 모드 활성화 시도\n", g_configs.size());
             g_master_ctx.is_active = true;
+            const StreamConfigNative& first_cfg = g_configs.front();
+            const int fps = (first_cfg.framerate > 0) ? first_cfg.framerate : 30;
+            const int out_w = (first_cfg.width > 0) ? first_cfg.width : 1920;
+            const int out_h = (first_cfg.height > 0) ? first_cfg.height : 1080;
+            const int bitrate = (first_cfg.bitrate_kbps > 0) ? first_cfg.bitrate_kbps : 8000;
+            const int keyint = (first_cfg.keyframe_interval > 0) ? first_cfg.keyframe_interval : fps;
+            const bool use_nvenc = first_cfg.enable_hw_accel && is_nvidia_system();
+            const char* encoder_name = use_nvenc ? "nvh264enc" : "x264enc";
 
-            // [핵심 변경] 시스템 메모리로 다운로드(d3d11download)를 명시적으로 거치게 하여 
-            // 어떤 인코더(x264enc, qsvh264enc 등)가 붙든 호환성 문제가 없도록 안전한 파이프라인을 구축합니다.
-            // 또는 시스템 환경에 따라 qsvh264enc를 하드코딩하셔도 됩니다.
-            //std::string pipe_desc =
-            //    "d3d11screencapturesrc monitor-index=0 show-cursor=true ! "
-            //    "video/x-raw(memory:D3D11Memory),framerate=30/1 ! "
-            //    "d3d11convert ! " // 여기서 크기 변환(Scaling)과 포맷 변환을 동시에 수행
-            //    // [핵심 추가] width=960, height=540 을 강제하여 540p로 리사이징
-            //    "video/x-raw(memory:D3D11Memory),format=NV12,width=640,height=480 ! "
-            //    "d3d11download ! "  
-            //    "video/x-raw,format=NV12 ! "
-            //    // 540p 해상도이므로 비트레이트를 3000 -> 1000~1500 수준으로 낮춰도 화질이 충분하며 클라이언트 부하가 크게 줄어듭니다.
-            //    "qsvh264enc bitrate=2500 target-usage=4 ! "
-            //    "h264parse config-interval=1 ! "
-            //    "video/x-h264,stream-format=byte-stream,alignment=au ! "
-            //    "appsink name=master_sink emit-signals=true sync=false drop=true max-buffers=10";
-            //std::string pipe_desc =
-            //    "d3d11screencapturesrc monitor-index=0 show-cursor=true ! "
-            //    "video/x-raw(memory:D3D11Memory),framerate=60/1 ! "
-            //    "d3d11convert ! "
-            //    //"video/x-raw(memory:D3D11Memory),format=NV12,width=640,height=480 ! "
-            //    "video/x-raw(memory:D3D11Memory),format=NV12,width=3840,height=2160 ! "
-            //    "d3d11download ! "
-            //    "video/x-raw,format=NV12 ! "
-            //    //"qsvh264enc bitrate=2000 target-usage=7 ! "
-            //    "nvh264enc bitrate=20000 target-usage=7 ! "
-            //    "h264parse config-interval=1 ! "
-            //    "video/x-h264,stream-format=byte-stream,alignment=au ! "
-            //    "appsink name=master_sink emit-signals=true sync=false drop=true max-buffers=10";
-            std::string pipe_desc =
-                "d3d11screencapturesrc monitor-index=0 show-cursor=true ! "
-                "video/x-raw(memory:D3D11Memory),framerate=60/1 ! "
-                "d3d11convert ! "
-                "video/x-raw(memory:D3D11Memory),format=NV12,width=3840,height=2160 ! "
-                "d3d11download ! "
-                "video/x-raw,format=NV12 ! "
-                "nvh264enc bitrate=20000 preset=p1 ! " // <-- 이 부분을 수정했습니다.
-                "h264parse config-interval=1 ! "
-                "video/x-h264,stream-format=byte-stream,alignment=au ! "
-                "appsink name=master_sink emit-signals=true sync=false drop=true max-buffers=10";
+            std::ostringstream pipe_desc;
+            pipe_desc
+                << "d3d11screencapturesrc monitor-index=" << first_cfg.monitor_index << " show-cursor=true ! "
+                << "video/x-raw(memory:D3D11Memory),framerate=" << fps << "/1 ! "
+                << "d3d11convert ! "
+                << "video/x-raw(memory:D3D11Memory),format=NV12,width=" << out_w << ",height=" << out_h << " ! "
+                << "d3d11download ! "
+                << "video/x-raw,format=NV12 ! "
+                << encoder_name << " bitrate=" << bitrate;
+
+            if (use_nvenc) {
+                pipe_desc << " preset=p1";
+            }
+            else {
+                pipe_desc << " key-int-max=" << keyint << " tune=zerolatency";
+            }
+
+            pipe_desc
+                << " ! h264parse config-interval=1 ! "
+                << "video/x-h264,stream-format=byte-stream,alignment=au ! "
+                << "appsink name=master_sink emit-signals=true sync=false drop=true max-buffers=10";
 
             GError* err = nullptr;
-            g_master_ctx.pipeline = gst_parse_launch(pipe_desc.c_str(), &err);
+            const std::string pipe_desc_str = pipe_desc.str();
+            g_print(">>> Shared Master Pipeline: %s\n", pipe_desc_str.c_str());
+            g_master_ctx.pipeline = gst_parse_launch(pipe_desc_str.c_str(), &err);
 
             if (err) {
                 g_printerr(">>> Shared Master Pipeline fail create: %s\n", err->message);


### PR DESCRIPTION
### Motivation
- Start the shared (copy) master pipeline earlier (at 5 streams) to match expected behavior for high stream counts. 
- Use the first stream's settings as the authoritative source for shared pipeline parameters instead of a hardcoded pipeline string. 
- Reduce UI complexity when many streams are requested by creating a single editable tab and replicating its settings for all streams.

### Description
- Introduced `kSharedMasterPipelineThreshold = 5` and switch the shared master pipeline activation to `>=` that threshold in `GstPlayer/ScreenCaptureServer.cpp`.
- Replaced the previously hardcoded shared pipeline description with a dynamically generated pipeline string based on the first `StreamConfigNative` (uses `monitor_index`, `framerate`, `width`, `height`, `bitrate_kbps`, `keyframe_interval`, and HW accel), selects `nvh264enc` on NVIDIA+HW accel otherwise `x264enc`, and logs the final pipeline string.
- Added `streamTabCollapseThreshold = 5` to `GStreamerDotNetTest/MainWindow.xaml.cs` and changed `UpdateStreamTabs` to create only one tab when requested stream count is `>= 5`.
- Refactored `CollectStreamConfigs` into `BuildConfigFromSetting` + `CollectStreamConfigs` so when the requested stream count is large, the first tab's settings are replicated across all streams while assigning per-stream `Port` and `StreamIndex`.

### Testing
- Attempted to run `dotnet build StreamerGst.sln -v minimal` in this environment, but the command failed because `dotnet` is not installed (`/bin/bash: line 1: dotnet: command not found`).
- No other automated build or unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c9eb663fec832f849ad3fcb1936f3d)